### PR TITLE
Add homepage competitive leaderboard

### DIFF
--- a/src/components/ScoreSubmitForm.svelte
+++ b/src/components/ScoreSubmitForm.svelte
@@ -1,0 +1,33 @@
+<script>
+	import { submitScore } from '/src/lib/scoreApi.js';
+
+	/** @type {number} */
+	export let score;
+	/** @type {string} */
+	export let round;
+	export let resetSignal = 0;
+
+	let userName = '';
+	let submitted = false;
+	let previousResetSignal = resetSignal;
+
+	$: if (resetSignal !== previousResetSignal) {
+		previousResetSignal = resetSignal;
+		submitted = false;
+	}
+
+	async function handleSubmit() {
+		const response = await submitScore(score, userName, round);
+		if (response !== undefined) {
+			submitted = true;
+		}
+	}
+</script>
+
+{#if !submitted}
+	<br /><br />
+	<h3>Trimite scor</h3>
+	<label for="userName">Nume:</label>
+	<input bind:value={userName} />
+	<button on:click={handleSubmit}>Trimite</button>
+{/if}

--- a/src/components/SequentialTraining.svelte
+++ b/src/components/SequentialTraining.svelte
@@ -1,10 +1,14 @@
 <script>
     import VersesInput from '/src/components/VersesInput.svelte';
     import WrittenText from '/src/components/WrittenText.svelte';
+    import { shouldRefetchScores } from '/src/stores/scoresStore.js';
 
     export let bookName;
     export let chapters;
     export let useRollingSumVerseIdx;
+    export let competitiveMode = false;
+    export let round = '';
+    export let competitionResetSignal = 0;
 
     export let start = {
         chapter: 1,
@@ -12,20 +16,19 @@
     }
 
     $: if (bookName !== undefined) {
-        discoveredVerseText = ''
+        resetChapter();
     }
 
     let rollingSumVerseIdx = 0;
     $: if (useRollingSumVerseIdx) {
         let sum = 0;
-        console.log(chapterIdx);
         for (let i = 0; i < chapterIdx; i++) {
             sum += chapters[i].length;
         }
         rollingSumVerseIdx = sum;
     }
 
-    let chapterIdx = start.chapter-1;
+    export let chapterIdx = start.chapter-1;
     /**
      * @type {string[]}
      */
@@ -42,7 +45,10 @@
 
     let startVerseInput = start.verse;
     $: {
-        if (startVerseInput < 1) {
+        if (competitiveMode) {
+            startVerseInput = 1;
+            start.verse = 1;
+        } else if (startVerseInput < 1) {
             start.verse = 1;
         } else if (startVerseInput > crtChapter.length) {
             start.verse = crtChapter.length;
@@ -53,18 +59,121 @@
 
     const jumpToChapter = (/** @type {number} */ i) => () => {
         chapterIdx = i;
-        verseIdx = start.verse - 1;
-        discoveredVerseText = '';
+        resetChapter();
     }
 
     let discoveredVerseText = '';
+
+    let resetVersesInput = () => 0;
+    let userName = '';
+    let submittedScore = false;
+    let eligibleForScoring = false;
+
+    let timerStarted = false;
+    let startTime = 0;
+    let endTime = null;
+    let interval = 0;
+    let elapsedTime = 0;
+
+    let previousCompetitionResetSignal = competitionResetSignal;
+
+    $: if (competitionResetSignal !== previousCompetitionResetSignal) {
+        previousCompetitionResetSignal = competitionResetSignal;
+        resetChapter();
+    }
+
+    $: if (!competitiveMode) {
+        eligibleForScoring = false;
+    }
+
+    $: if (!timerStarted && competitiveMode && discoveredVerseText.length > 0) {
+        timerStarted = true;
+        startTimer();
+    }
+
+    $: if (timerStarted && verseIdx == crtChapter.length) {
+        stopTimer();
+    }
+
+    function resetChapter() {
+        stopTimer();
+        elapsedTime = 0;
+        endTime = null;
+        verseIdx = start.verse - 1;
+        discoveredVerseText = '';
+        submittedScore = false;
+        eligibleForScoring = false;
+        timerStarted = false;
+        resetVersesInput();
+    }
+
+    function startTimer() {
+        startTime = new Date().getTime();
+        eligibleForScoring = competitiveMode;
+        elapsedTime = 0;
+        interval = setInterval(() => {
+            elapsedTime = (new Date().getTime() - startTime) / 1000;
+        }, 100);
+    }
+
+    function stopTimer() {
+        if (!timerStarted) {
+            return;
+        }
+
+        endTime = new Date().getTime();
+        clearInterval(interval);
+        elapsedTime = (endTime - startTime) / 1000;
+    }
+
+    /**
+	 * @param {number} score
+	 * @param {string} name
+	 * @param {string} scoreRound
+	 */
+    async function submitScore(score, name, scoreRound) {
+        if (name === '') {
+            alert('Numele nu poate fi gol');
+            return;
+        }
+
+        if (score < 0.01) {
+            alert('Timpul nu poate fi 0');
+            return;
+        }
+
+        const response = await fetch(
+            'https://dz5rd0lqnb.execute-api.eu-central-1.amazonaws.com/Prod/scores',
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    score,
+                    name,
+                    round: scoreRound
+                })
+            }
+        );
+
+        if (!response.ok) {
+            throw new Error(`API request failed with status ${response.status}`);
+        }
+
+        const responseData = await response.json();
+        submittedScore = true;
+        shouldRefetchScores.set(true);
+
+        return responseData;
+    }
 </script>
 
 <h2>{bookName} - Capitolul {chapterIdx+1}</h2>
 <WrittenText startIdx={rollingSumVerseIdx+start.verse} verses={crtChapter.slice(start.verse-1, verseIdx).concat(verseIdx < crtChapter.length ? [discoveredVerseText] : [])}></WrittenText>
 <br>
 {#key crtVerse}
-    <VersesInput inputText={crtVerse} fnVerseDone={() => {verseIdx++; discoveredVerseText = ''}} bind:discoveredText={discoveredVerseText}></VersesInput>
+    <VersesInput inputText={crtVerse} fnVerseDone={() => {verseIdx++; discoveredVerseText = ''}} bind:discoveredText={discoveredVerseText} disableNextButton={competitiveMode} bind:reset={resetVersesInput}></VersesInput>
 {/key}
 <br>
 <br>
@@ -82,7 +191,21 @@
         </tr>
     </tbody>
 </table>
-<p>Începând cu versetul <input type=number bind:value={startVerseInput}></p>
+{#if !competitiveMode}
+    <p>Începând cu versetul <input type=number bind:value={startVerseInput}></p>
+{/if}
+{#if competitiveMode}
+    <div class="timer">
+        Timp: {elapsedTime} secunde
+    </div>
+{/if}
+{#if eligibleForScoring && !submittedScore && verseIdx == crtChapter.length}
+    <br><br>
+    <h3>Trimite scor</h3>
+    <label for="userName">Nume:</label>
+    <input bind:value={userName} />
+    <button on:click={() => submitScore(elapsedTime, userName, round)}>Trimite</button>
+{/if}
 <button on:click={jumpToChapter(chapterIdx)}>
     Resetează capitolul
 </button>

--- a/src/components/SequentialTraining.svelte
+++ b/src/components/SequentialTraining.svelte
@@ -15,10 +15,6 @@
         verse: 1,
     }
 
-    $: if (bookName !== undefined) {
-        resetChapter();
-    }
-
     let rollingSumVerseIdx = 0;
     $: if (useRollingSumVerseIdx) {
         let sum = 0;
@@ -29,6 +25,14 @@
     }
 
     export let chapterIdx = start.chapter-1;
+    let previousBookName = '';
+    $: if (bookName !== previousBookName) {
+        previousBookName = bookName;
+        if (chapterIdx >= chapters.length) {
+            chapterIdx = 0;
+        }
+        resetChapter();
+    }
     /**
      * @type {string[]}
      */

--- a/src/components/SequentialTraining.svelte
+++ b/src/components/SequentialTraining.svelte
@@ -9,6 +9,7 @@
     export let competitiveMode = false;
     export let round = '';
     export let competitionResetSignal = 0;
+    export let hasProgress = false;
 
     export let start = {
         chapter: 1,
@@ -89,6 +90,8 @@
     $: if (!competitiveMode) {
         eligibleForScoring = false;
     }
+
+    $: hasProgress = verseIdx !== start.verse - 1 || discoveredVerseText.length > 0;
 
     $: if (!timerStarted && competitiveMode && discoveredVerseText.length > 0) {
         timerStarted = true;

--- a/src/components/SequentialTraining.svelte
+++ b/src/components/SequentialTraining.svelte
@@ -1,7 +1,8 @@
 <script>
     import VersesInput from '/src/components/VersesInput.svelte';
     import WrittenText from '/src/components/WrittenText.svelte';
-    import { shouldRefetchScores } from '/src/stores/scoresStore.js';
+    import ScoreSubmitForm from '/src/components/ScoreSubmitForm.svelte';
+    import { createStopwatch } from '/src/lib/stopwatch.js';
 
     export let bookName;
     export let chapters;
@@ -70,15 +71,13 @@
     let discoveredVerseText = '';
 
     let resetVersesInput = () => 0;
-    let userName = '';
-    let submittedScore = false;
     let eligibleForScoring = false;
+    let scoreResetSignal = 0;
 
-    let timerStarted = false;
-    let startTime = 0;
-    let endTime = null;
-    let interval = 0;
-    let elapsedTime = 0;
+    const stopwatch = createStopwatch();
+    const stopwatchState = stopwatch.state;
+    $: timerStarted = $stopwatchState.hasStarted;
+    $: elapsedTime = $stopwatchState.elapsedTime;
 
     let previousCompetitionResetSignal = competitionResetSignal;
 
@@ -94,85 +93,21 @@
     $: hasProgress = verseIdx !== start.verse - 1 || discoveredVerseText.length > 0;
 
     $: if (!timerStarted && competitiveMode && discoveredVerseText.length > 0) {
-        timerStarted = true;
-        startTimer();
+        eligibleForScoring = competitiveMode;
+        stopwatch.start();
     }
 
     $: if (timerStarted && verseIdx == crtChapter.length) {
-        stopTimer();
+        stopwatch.stop();
     }
 
     function resetChapter() {
-        stopTimer();
-        elapsedTime = 0;
-        endTime = null;
+        stopwatch.reset();
+        scoreResetSignal++;
         verseIdx = start.verse - 1;
         discoveredVerseText = '';
-        submittedScore = false;
         eligibleForScoring = false;
-        timerStarted = false;
         resetVersesInput();
-    }
-
-    function startTimer() {
-        startTime = new Date().getTime();
-        eligibleForScoring = competitiveMode;
-        elapsedTime = 0;
-        interval = setInterval(() => {
-            elapsedTime = (new Date().getTime() - startTime) / 1000;
-        }, 100);
-    }
-
-    function stopTimer() {
-        if (!timerStarted) {
-            return;
-        }
-
-        endTime = new Date().getTime();
-        clearInterval(interval);
-        elapsedTime = (endTime - startTime) / 1000;
-    }
-
-    /**
-	 * @param {number} score
-	 * @param {string} name
-	 * @param {string} scoreRound
-	 */
-    async function submitScore(score, name, scoreRound) {
-        if (name === '') {
-            alert('Numele nu poate fi gol');
-            return;
-        }
-
-        if (score < 0.01) {
-            alert('Timpul nu poate fi 0');
-            return;
-        }
-
-        const response = await fetch(
-            'https://dz5rd0lqnb.execute-api.eu-central-1.amazonaws.com/Prod/scores',
-            {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    score,
-                    name,
-                    round: scoreRound
-                })
-            }
-        );
-
-        if (!response.ok) {
-            throw new Error(`API request failed with status ${response.status}`);
-        }
-
-        const responseData = await response.json();
-        submittedScore = true;
-        shouldRefetchScores.set(true);
-
-        return responseData;
     }
 </script>
 
@@ -206,12 +141,8 @@
         Timp: {elapsedTime} secunde
     </div>
 {/if}
-{#if eligibleForScoring && !submittedScore && verseIdx == crtChapter.length}
-    <br><br>
-    <h3>Trimite scor</h3>
-    <label for="userName">Nume:</label>
-    <input bind:value={userName} />
-    <button on:click={() => submitScore(elapsedTime, userName, round)}>Trimite</button>
+{#if eligibleForScoring && verseIdx == crtChapter.length}
+    <ScoreSubmitForm score={elapsedTime} {round} resetSignal={scoreResetSignal} />
 {/if}
 <button on:click={jumpToChapter(chapterIdx)}>
     Resetează capitolul

--- a/src/components/concursgrupa/ConcursGrupa.svelte
+++ b/src/components/concursgrupa/ConcursGrupa.svelte
@@ -1,7 +1,8 @@
 <script>
 	import VersesInput from '/src/components/VersesInput.svelte';
 	import WrittenText from '/src/components/WrittenText.svelte';
-	import { shouldRefetchScores } from '/src/stores/scoresStore.js';
+	import ScoreSubmitForm from '/src/components/ScoreSubmitForm.svelte';
+	import { createStopwatch } from '/src/lib/stopwatch.js';
 
 	export let round;
 	export let verses;
@@ -10,21 +11,15 @@
 	 */
      export let trainingMode;
 
-	let userName = '';
-	let submittedScore = false;
     let eligibleForScoring = false;
+	let scoreResetSignal = 0;
 
 	let resetVersesInput = () => 0;
 
-	// countdown vars
-    let timerStarted = false;
-	/**
-	 * @type {number}
-	 */
-	let startTime = 0;
-	let endTime = null;
-	let interval = 0;
-	let elapsedTime = 0;
+	const stopwatch = createStopwatch();
+	const stopwatchState = stopwatch.state;
+	$: timerStarted = $stopwatchState.hasStarted;
+	$: elapsedTime = $stopwatchState.elapsedTime;
 
 	let verseIdx = 0;
 	$: if (verses) {
@@ -43,86 +38,26 @@
 	let discoveredVerseText = '';
 
     $: if (!timerStarted && discoveredVerseText.length > 0) {
-        timerStarted = true;
-        startTimer();
+        if (!trainingMode) {
+            eligibleForScoring = true;
+        }
+        stopwatch.start();
     }
 
     $: if (timerStarted && verseIdx == verses.length) {
-        stopTimer();
+        stopwatch.stop();
     }
 
     $: if (trainingMode) {
         eligibleForScoring = false;
     }
 
-	/**
-	 * @param {number} score
-	 * @param {string} name
-	 * @param {string} round
-	 */
-	async function submitScore(score, name, round) {
-		if (name === '') {
-			alert('Numele nu poate fi gol');
-			return;
-		}
-        if (score < 0.01) {
-            alert('Timpul nu poate fi 0')
-            return;
-        }
-		const data = {
-			score,
-			name,
-			round
-		};
-
-		const response = await fetch(
-			'https://dz5rd0lqnb.execute-api.eu-central-1.amazonaws.com/Prod/scores',
-			{
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify(data)
-			}
-		);
-
-		if (!response.ok) {
-			throw new Error(`API request failed with status ${response.status}`);
-		}
-
-		const responseData = await response.json();
-		submittedScore = true;
-
-		// Indicate that scores need to be refetched
-		shouldRefetchScores.set(true);
-
-		return responseData; // Handle successful response and return data if needed
-	}
-
-	function startTimer() {
-		startTime = new Date().getTime();
-        if (!trainingMode) {
-            eligibleForScoring = true;
-        }
-		elapsedTime = 0;
-		interval = setInterval(() => {
-			elapsedTime = (new Date().getTime() - startTime) / 1000;
-		}, 100);
-	}
-
-	function stopTimer() {
-		endTime = new Date().getTime();
-		clearInterval(interval);
-		elapsedTime = (endTime - startTime) / 1000;
-	}
-
     function reset() {
-        stopTimer();
-        elapsedTime = 0;
+        stopwatch.reset();
+		scoreResetSignal++;
         verseIdx = 0;
         discoveredVerseText = '';
-        submittedScore = false;
-        timerStarted = false;
+		eligibleForScoring = false;
 		resetVersesInput();
     }
 </script>
@@ -156,12 +91,8 @@
 	/>
 {/key}
 
-{#if eligibleForScoring && !submittedScore && verseIdx == verses.length}
-	<br /><br />
-    <h3>Trimite scor</h3>
-    <label for="userName">Nume:</label>
-	<input bind:value={userName} />
-	<button on:click={() => submitScore(elapsedTime, userName, round)}>Trimite</button>
+{#if eligibleForScoring && verseIdx == verses.length}
+	<ScoreSubmitForm score={elapsedTime} {round} resetSignal={scoreResetSignal} />
 {/if}
 <br><br>
 <div class="timer">

--- a/src/components/concursgrupa/ScoreBoard.svelte
+++ b/src/components/concursgrupa/ScoreBoard.svelte
@@ -4,21 +4,32 @@
 	import Icon from '../Icon.svelte';
 
 	export let round = 'Runda1';
+	export let title = `Clasament ${round}`;
 
 	/**
 	 * @type {string | any[]}
 	 */
 	let scores = [];
+	let fetchedRound = '';
+	let mounted = false;
 
 	async function fetchData() {
+		fetchedRound = round;
 		const response = await fetch(
-			'https://dz5rd0lqnb.execute-api.eu-central-1.amazonaws.com/Prod/scores?round=' + round
+			'https://dz5rd0lqnb.execute-api.eu-central-1.amazonaws.com/Prod/scores?round=' + encodeURIComponent(round)
 		);
 		const data = await response.json();
 		scores = data['body'].slice(0, 10); // Limit to top 10 scores
 	}
 
-	onMount(fetchData);
+	$: if (mounted && round !== fetchedRound) {
+		fetchData();
+	}
+
+	onMount(() => {
+		mounted = true;
+		fetchData();
+	});
 
 	// Subscribe to store and refetch scores when the value changes
 	shouldRefetchScores.subscribe((/** @type {boolean} */ value) => {
@@ -32,7 +43,7 @@
 <table class="scoreboard">
 	<thead>
 		<tr>
-			<th colspan="3">Clasament {round}</th>
+			<th colspan="3">{title}</th>
 		</tr>
 		<tr>
 			<th>Loc</th>

--- a/src/lib/scoreApi.js
+++ b/src/lib/scoreApi.js
@@ -1,0 +1,41 @@
+import { shouldRefetchScores } from '/src/stores/scoresStore.js';
+
+const SCORES_URL = 'https://dz5rd0lqnb.execute-api.eu-central-1.amazonaws.com/Prod/scores';
+
+/**
+ * @param {number} score
+ * @param {string} name
+ * @param {string} round
+ */
+export async function submitScore(score, name, round) {
+  if (name === '') {
+    alert('Numele nu poate fi gol');
+    return;
+  }
+
+  if (score < 0.01) {
+    alert('Timpul nu poate fi 0');
+    return;
+  }
+
+  const response = await fetch(SCORES_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      score,
+      name,
+      round
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed with status ${response.status}`);
+  }
+
+  const responseData = await response.json();
+  shouldRefetchScores.set(true);
+
+  return responseData;
+}

--- a/src/lib/stopwatch.js
+++ b/src/lib/stopwatch.js
@@ -1,0 +1,57 @@
+import { writable } from 'svelte/store';
+
+const initialState = {
+  hasStarted: false,
+  elapsedTime: 0
+};
+
+export function createStopwatch() {
+  let startTime = 0;
+  let interval = 0;
+
+  const state = writable({ ...initialState });
+
+  function start() {
+    startTime = new Date().getTime();
+    clearInterval(interval);
+    state.set({
+      hasStarted: true,
+      elapsedTime: 0
+    });
+
+    interval = setInterval(() => {
+      state.update((current) => ({
+        ...current,
+        elapsedTime: (new Date().getTime() - startTime) / 1000
+      }));
+    }, 100);
+  }
+
+  function stop() {
+    const endTime = new Date().getTime();
+    clearInterval(interval);
+    state.update((current) => {
+      if (!current.hasStarted) {
+        return current;
+      }
+
+      return {
+        ...current,
+        elapsedTime: (endTime - startTime) / 1000
+      };
+    });
+  }
+
+  function reset() {
+    clearInterval(interval);
+    startTime = 0;
+    state.set({ ...initialState });
+  }
+
+  return {
+    state,
+    start,
+    stop,
+    reset
+  };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,6 +14,7 @@
     let exitedCompetitiveMode = false;
     let competitionResetSignal = 0;
     let chapterIdx = start.chapter - 1;
+    let hasChapterProgress = false;
 
     $: selectedRound = `homepage:${bookName}:${chapterIdx + 1}`;
     $: selectedChapterTitle = `${bookName} ${chapterIdx + 1}`;
@@ -22,6 +23,7 @@
         if (competitiveMode) {
             if (
                 exitedCompetitiveMode &&
+                hasChapterProgress &&
                 !confirm('Progresul se va reseta deoarece modul competitiv poate începe doar de la versetul 1. Continui?')
             ) {
                 competitiveMode = false;
@@ -57,6 +59,7 @@
     chapters={chapters[bookName]}
     start={start}
     bind:chapterIdx
+    bind:hasProgress={hasChapterProgress}
     competitiveMode={competitiveMode}
     competitionResetSignal={competitionResetSignal}
     round={selectedRound}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script>
     import SequentialTraining from '/src/components/SequentialTraining.svelte';
+    import ScoreBoard from '/src/components/concursgrupa/ScoreBoard.svelte';
     import {chapters} from '/src/data/verses';
 
     let bookName = 'Evrei'
@@ -8,6 +9,32 @@
         verse: 1
     }
     let bookEntries = Object.entries(chapters)
+
+    let competitiveMode = false;
+    let exitedCompetitiveMode = false;
+    let competitionResetSignal = 0;
+    let chapterIdx = start.chapter - 1;
+
+    $: selectedRound = `homepage:${bookName}:${chapterIdx + 1}`;
+    $: selectedChapterTitle = `${bookName} ${chapterIdx + 1}`;
+
+    function handleCompetitiveModeChange() {
+        if (competitiveMode) {
+            if (
+                exitedCompetitiveMode &&
+                !confirm('Progresul se va reseta deoarece modul competitiv poate începe doar de la versetul 1. Continui?')
+            ) {
+                competitiveMode = false;
+                return;
+            }
+
+            start.verse = 1;
+            competitionResetSignal += 1;
+            return;
+        }
+
+        exitedCompetitiveMode = true;
+    }
 </script>
 
 <h1>Romanii</h1>
@@ -17,6 +44,22 @@
         <option value={name}>{name}</option>
     {/each}
 </select>
-<SequentialTraining bookName={bookName} chapters={chapters[bookName]} start={start}/>
+<br><br>
+<label for="competitiveMode" style="font-weight: bold">Mod competitiv:</label>
+<input id="competitiveMode" type="checkbox" bind:checked={competitiveMode} on:change={handleCompetitiveModeChange} />
+<br>
+{#if competitiveMode}
+    <p>Modul competitiv începe întotdeauna de la versetul 1 și permite trimiterea scorului la finalul capitolului.</p>
+    <ScoreBoard round={selectedRound} title={`Clasament ${selectedChapterTitle}`} />
+{/if}
+<SequentialTraining
+    bookName={bookName}
+    chapters={chapters[bookName]}
+    start={start}
+    bind:chapterIdx
+    competitiveMode={competitiveMode}
+    competitionResetSignal={competitionResetSignal}
+    round={selectedRound}
+/>
 <br><br>
 <a href="/randomverses">Versete aleatoare</a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a homepage `Mod competitiv` checkbox that resets chapter progress to verse 1 and confirms re-entry only when progress exists.
- Show a chapter-specific leaderboard only in competitive mode, keyed by selected book and chapter.
- Let users submit timed scores only after finishing a chapter they started in competitive mode.
- Reset invalid chapter selections when changing to a shorter book.

### Walkthrough
[competitive_mode_reentry_warning.mp4](https://cursor.com/agents/bc-c0b77782-28f5-4311-b023-2ad5eeb028ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompetitive_mode_reentry_warning.mp4)

### Testing
- `npm run build` passes.
- Browser automation verified competitive mode hides the starting verse input, shows chapter leaderboard/timer, skips the re-entry confirmation with no progress, and shows the confirmation after progress exists.
- `npm run check` currently fails because of existing project-wide Svelte-check issues with `/src/...` imports and implicit anys in existing components.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0b77782-28f5-4311-b023-2ad5eeb028ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0b77782-28f5-4311-b023-2ad5eeb028ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

