### PR TITLE
Local run history with per-verse + total-time charts for Competitive mode

### DIFF
--- a/src/components/RunHistory.svelte
+++ b/src/components/RunHistory.svelte
@@ -8,10 +8,14 @@
     export let title = 'Istoric încercări';
     /** @type {string[]} */
     export let verseLabels = [];
+    /** @type {number[]} */
+    export let verseWordCounts = [];
     /** Optional latest run id to auto-highlight after a finish. */
     export let highlightRunId = '';
 
     let expanded = false;
+    /** @type {'wpm' | 'seconds'} */
+    let metric = 'wpm';
     /** @type {Set<string>} */
     let selectedIds = new Set();
 
@@ -21,9 +25,22 @@
         '#9c755f', '#bab0ac'
     ];
 
+    $: hasWordCounts = verseWordCounts && verseWordCounts.length > 0;
+    $: if (!hasWordCounts && metric === 'wpm') {
+        metric = 'seconds';
+    }
+
     $: allRuns = (($runHistoryStore || {})[round] || [])
         .slice()
         .sort((a, b) => b.timestamp - a.timestamp);
+
+    // Total WPM for a run, given the current chapter's verseWordCounts.
+    function totalWpm(run) {
+        if (!hasWordCounts || !run || run.totalTime <= 0) return null;
+        const totalWords = verseWordCounts.reduce((a, b) => a + (b || 0), 0);
+        if (totalWords <= 0) return null;
+        return (totalWords / run.totalTime) * 60;
+    }
 
     // Auto-select latest run + any newly-finished run
     let lastSelectedSignature = '';
@@ -32,13 +49,10 @@
         if (signature !== lastSelectedSignature) {
             lastSelectedSignature = signature;
             const next = new Set(selectedIds);
-            // Keep selections that still exist
             for (const id of [...next]) {
                 if (!allRuns.find((r) => r.id === id)) next.delete(id);
             }
-            // Always include latest run if any
             if (allRuns[0]) next.add(allRuns[0].id);
-            // Include newly-finished run if provided
             if (highlightRunId && allRuns.find((r) => r.id === highlightRunId)) {
                 next.add(highlightRunId);
             }
@@ -46,18 +60,15 @@
         }
     }
 
-    // Auto-expand panel when a run is just saved
     let prevHighlight = '';
     $: if (highlightRunId && highlightRunId !== prevHighlight) {
         prevHighlight = highlightRunId;
         expanded = true;
     }
 
-    // Build the ordered list of runs to chart. Latest selected run (by timestamp)
-    // is first so PerVerseChart can render it as the highlighted/bar series.
     $: chartedRuns = (() => {
         const picked = allRuns.filter((r) => selectedIds.has(r.id));
-        return picked; // already sorted desc by timestamp
+        return picked;
     })();
 
     function toggleSelected(id) {
@@ -111,11 +122,41 @@
 
         {#if expanded}
             <div class="panel">
-                <h4>Timp pe verset</h4>
+                <div class="chart-header">
+                    <h4>{metric === 'wpm' ? 'Viteza pe verset (cuv/min)' : 'Timp pe verset (secunde)'}</h4>
+                    {#if hasWordCounts}
+                        <div class="metric-toggle" role="tablist" aria-label="Unitate de măsură">
+                            <button
+                                class="small"
+                                class:active={metric === 'wpm'}
+                                on:click={() => (metric = 'wpm')}
+                                title="Cuvinte pe minut (normalizat după lungimea versetului)"
+                            >cuv/min</button>
+                            <button
+                                class="small"
+                                class:active={metric === 'seconds'}
+                                on:click={() => (metric = 'seconds')}
+                                title="Timp brut pe verset"
+                            >secunde</button>
+                        </div>
+                    {/if}
+                </div>
                 <p class="hint">
-                    Bara roșie reprezintă ultima încercare. Bifează încercări din listă pentru a le compara.
+                    {#if metric === 'wpm'}
+                        Bara roșie e ultima încercare. <strong>Mai înalt = mai rapid.</strong> Lungimea versetului
+                        este normalizată — așa că un verset lung dar tipărit rapid nu mai arată „lent”.
+                    {:else}
+                        Bara roșie e ultima încercare. <strong>Mai înalt = mai lent.</strong> Versetele lungi
+                        apar în mod natural ca bare mai înalte.
+                    {/if}
+                    Bifează încercări din listă pentru a le compara.
                 </p>
-                <PerVerseChart runs={chartedRuns} verseLabels={verseLabels} />
+                <PerVerseChart
+                    runs={chartedRuns}
+                    verseLabels={verseLabels}
+                    verseWordCounts={verseWordCounts}
+                    metric={metric}
+                />
 
                 {#if allRuns.length > 1}
                     <h4>Evoluția timpului total</h4>
@@ -129,6 +170,9 @@
                             <th></th>
                             <th>Data</th>
                             <th>Total (s)</th>
+                            {#if hasWordCounts}
+                                <th>cuv/min</th>
+                            {/if}
                             <th>Δ</th>
                             <th></th>
                             <th></th>
@@ -151,6 +195,9 @@
                                 </td>
                                 <td>{formatTimestamp(run.timestamp)}{i === 0 ? ' (ultima)' : ''}</td>
                                 <td class="num">{run.totalTime.toFixed(2)}</td>
+                                {#if hasWordCounts}
+                                    <td class="num">{totalWpm(run) !== null ? totalWpm(run).toFixed(1) : '-'}</td>
+                                {/if}
                                 <td class="delta">{formatDelta(run)}</td>
                                 <td>
                                     {#if i !== 0}
@@ -217,6 +264,36 @@
     .panel h4:first-child {
         margin-top: 0;
     }
+    .chart-header {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        flex-wrap: wrap;
+    }
+    .chart-header h4 {
+        margin: 0;
+    }
+    .metric-toggle {
+        display: inline-flex;
+        gap: 0;
+        border: 1px solid #c0c0c0;
+        border-radius: 4px;
+        overflow: hidden;
+    }
+    .metric-toggle button.small {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        padding: 2px 10px;
+        cursor: pointer;
+    }
+    .metric-toggle button.small + button.small {
+        border-left: 1px solid #c0c0c0;
+    }
+    .metric-toggle button.small.active {
+        background: rgba(225, 87, 89, 0.15);
+        font-weight: bold;
+    }
     .hint {
         color: #666;
         font-size: 0.9em;
@@ -276,6 +353,15 @@
     }
     :global(body.dark-mode) .panel {
         border-color: #3a4c61;
+    }
+    :global(body.dark-mode) .metric-toggle {
+        border-color: #3a4c61;
+    }
+    :global(body.dark-mode) .metric-toggle button.small + button.small {
+        border-left-color: #3a4c61;
+    }
+    :global(body.dark-mode) .metric-toggle button.small.active {
+        background: rgba(225, 87, 89, 0.25);
     }
     :global(body.dark-mode) .runs-table th,
     :global(body.dark-mode) .runs-table td {

--- a/src/components/RunHistory.svelte
+++ b/src/components/RunHistory.svelte
@@ -1,0 +1,294 @@
+<script>
+    // @ts-nocheck
+    import { runHistoryStore, deleteRun, clearRound, formatTimestamp } from '/src/lib/runHistory.js';
+    import PerVerseChart from '/src/components/charts/PerVerseChart.svelte';
+    import TotalTimeChart from '/src/components/charts/TotalTimeChart.svelte';
+
+    export let round = '';
+    export let title = 'Istoric încercări';
+    /** @type {string[]} */
+    export let verseLabels = [];
+    /** Optional latest run id to auto-highlight after a finish. */
+    export let highlightRunId = '';
+
+    let expanded = false;
+    /** @type {Set<string>} */
+    let selectedIds = new Set();
+
+    const palette = [
+        '#e15759', '#4e79a7', '#f28e2b', '#76b7b2',
+        '#59a14f', '#edc948', '#b07aa1', '#ff9da7',
+        '#9c755f', '#bab0ac'
+    ];
+
+    $: allRuns = (($runHistoryStore || {})[round] || [])
+        .slice()
+        .sort((a, b) => b.timestamp - a.timestamp);
+
+    // Auto-select latest run + any newly-finished run
+    let lastSelectedSignature = '';
+    $: {
+        const signature = allRuns.map((r) => r.id).join('|');
+        if (signature !== lastSelectedSignature) {
+            lastSelectedSignature = signature;
+            const next = new Set(selectedIds);
+            // Keep selections that still exist
+            for (const id of [...next]) {
+                if (!allRuns.find((r) => r.id === id)) next.delete(id);
+            }
+            // Always include latest run if any
+            if (allRuns[0]) next.add(allRuns[0].id);
+            // Include newly-finished run if provided
+            if (highlightRunId && allRuns.find((r) => r.id === highlightRunId)) {
+                next.add(highlightRunId);
+            }
+            selectedIds = next;
+        }
+    }
+
+    // Auto-expand panel when a run is just saved
+    let prevHighlight = '';
+    $: if (highlightRunId && highlightRunId !== prevHighlight) {
+        prevHighlight = highlightRunId;
+        expanded = true;
+    }
+
+    // Build the ordered list of runs to chart. Latest selected run (by timestamp)
+    // is first so PerVerseChart can render it as the highlighted/bar series.
+    $: chartedRuns = (() => {
+        const picked = allRuns.filter((r) => selectedIds.has(r.id));
+        return picked; // already sorted desc by timestamp
+    })();
+
+    function toggleSelected(id) {
+        const next = new Set(selectedIds);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        selectedIds = next;
+    }
+
+    function selectOnly(id) {
+        selectedIds = new Set([id]);
+    }
+
+    function compareLatestVsRun(id) {
+        if (!allRuns[0]) return;
+        selectedIds = new Set([allRuns[0].id, id]);
+    }
+
+    function onDelete(id) {
+        if (!confirm('Sigur vrei să ștergi această încercare?')) return;
+        deleteRun(round, id);
+    }
+
+    function onClearAll() {
+        if (!confirm('Sigur vrei să ștergi tot istoricul pentru această rundă?')) return;
+        clearRound(round);
+        selectedIds = new Set();
+    }
+
+    function colorFor(id) {
+        const idx = chartedRuns.findIndex((r) => r.id === id);
+        if (idx < 0) return '#999';
+        return palette[idx % palette.length];
+    }
+
+    function formatDelta(run) {
+        if (!run || !allRuns[0] || allRuns[0].id === run.id) return '';
+        const diff = run.totalTime - allRuns[0].totalTime;
+        const sign = diff > 0 ? '+' : '';
+        return `(${sign}${diff.toFixed(2)}s vs ultimul)`;
+    }
+</script>
+
+{#if allRuns.length > 0}
+    <div class="run-history">
+        <button class="header-button" on:click={() => (expanded = !expanded)}>
+            <span class="caret">{expanded ? '▾' : '▸'}</span>
+            <strong>{title}</strong>
+            <span class="count">({allRuns.length})</span>
+        </button>
+
+        {#if expanded}
+            <div class="panel">
+                <h4>Timp pe verset</h4>
+                <p class="hint">
+                    Bara roșie reprezintă ultima încercare. Bifează încercări din listă pentru a le compara.
+                </p>
+                <PerVerseChart runs={chartedRuns} verseLabels={verseLabels} />
+
+                {#if allRuns.length > 1}
+                    <h4>Evoluția timpului total</h4>
+                    <TotalTimeChart runs={allRuns} highlightId={allRuns[0].id} />
+                {/if}
+
+                <h4>Încercări precedente</h4>
+                <table class="runs-table">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Data</th>
+                            <th>Total (s)</th>
+                            <th>Δ</th>
+                            <th></th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {#each allRuns as run, i (run.id)}
+                            <tr class:latest={i === 0}>
+                                <td>
+                                    <label class="legend-cell">
+                                        <input
+                                            type="checkbox"
+                                            checked={selectedIds.has(run.id)}
+                                            on:change={() => toggleSelected(run.id)}
+                                        />
+                                        {#if selectedIds.has(run.id)}
+                                            <span class="swatch" style="background: {colorFor(run.id)}"></span>
+                                        {/if}
+                                    </label>
+                                </td>
+                                <td>{formatTimestamp(run.timestamp)}{i === 0 ? ' (ultima)' : ''}</td>
+                                <td class="num">{run.totalTime.toFixed(2)}</td>
+                                <td class="delta">{formatDelta(run)}</td>
+                                <td>
+                                    {#if i !== 0}
+                                        <button class="small" on:click={() => compareLatestVsRun(run.id)}>
+                                            Compară cu ultima
+                                        </button>
+                                    {:else}
+                                        <button class="small" on:click={() => selectOnly(run.id)}>
+                                            Doar ultima
+                                        </button>
+                                    {/if}
+                                </td>
+                                <td>
+                                    <button class="small danger" on:click={() => onDelete(run.id)}>
+                                        Șterge
+                                    </button>
+                                </td>
+                            </tr>
+                        {/each}
+                    </tbody>
+                </table>
+
+                <div class="footer-actions">
+                    <button class="small danger" on:click={onClearAll}>
+                        Șterge tot istoricul
+                    </button>
+                    <span class="hint">Istoricul este salvat local în acest browser.</span>
+                </div>
+            </div>
+        {/if}
+    </div>
+{/if}
+
+<style>
+    .run-history {
+        margin: 12px 0;
+        max-width: 780px;
+    }
+    .header-button {
+        background: none;
+        border: 1px solid #c0c0c0;
+        padding: 6px 10px;
+        cursor: pointer;
+        text-align: left;
+        border-radius: 4px;
+    }
+    .caret {
+        display: inline-block;
+        width: 1em;
+    }
+    .count {
+        color: #888;
+        margin-left: 6px;
+    }
+    .panel {
+        margin-top: 10px;
+        padding: 10px 12px;
+        border: 1px solid #d8d8d8;
+        border-radius: 6px;
+    }
+    .panel h4 {
+        margin: 14px 0 6px;
+    }
+    .panel h4:first-child {
+        margin-top: 0;
+    }
+    .hint {
+        color: #666;
+        font-size: 0.9em;
+        margin: 0 0 8px;
+    }
+    .runs-table {
+        border-collapse: collapse;
+        width: 100%;
+        font-size: 0.95em;
+    }
+    .runs-table th,
+    .runs-table td {
+        padding: 4px 8px;
+        border-bottom: 1px solid #e5e5e5;
+        text-align: left;
+    }
+    .runs-table td.num {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+    }
+    .runs-table td.delta {
+        color: #666;
+        font-size: 0.9em;
+    }
+    .runs-table tr.latest td {
+        background: rgba(225, 87, 89, 0.06);
+        font-weight: bold;
+    }
+    .legend-cell {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .swatch {
+        display: inline-block;
+        width: 12px;
+        height: 12px;
+        border-radius: 2px;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+    }
+    button.small {
+        font-size: 0.85em;
+        padding: 2px 8px;
+    }
+    button.danger {
+        color: #b3261e;
+    }
+    .footer-actions {
+        margin-top: 10px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+    }
+    :global(body.dark-mode) .header-button {
+        border-color: #3a4c61;
+    }
+    :global(body.dark-mode) .panel {
+        border-color: #3a4c61;
+    }
+    :global(body.dark-mode) .runs-table th,
+    :global(body.dark-mode) .runs-table td {
+        border-bottom-color: #2c3a4a;
+    }
+    :global(body.dark-mode) .runs-table tr.latest td {
+        background: rgba(225, 87, 89, 0.12);
+    }
+    :global(body.dark-mode) .hint,
+    :global(body.dark-mode) .count {
+        color: #9aa6b4;
+    }
+    :global(body.dark-mode) .runs-table td.delta {
+        color: #9aa6b4;
+    }
+</style>

--- a/src/components/RunHistory.svelte
+++ b/src/components/RunHistory.svelte
@@ -143,11 +143,13 @@
                 </div>
                 <p class="hint">
                     {#if metric === 'wpm'}
-                        Bara roșie e ultima încercare. <strong>Mai înalt = mai rapid.</strong> Lungimea versetului
-                        este normalizată — așa că un verset lung dar tipărit rapid nu mai arată „lent”.
+                        Barele sunt ultima încercare. <strong>Mai înalt = mai rapid.</strong>
+                        <span class="legend-color">🟢 verde = cel mai rapid verset, 🔴 roșu = cel mai lent</span>.
+                        Lungimea versetului este normalizată, așa că un verset lung dar tipărit rapid nu mai arată „lent”.
                     {:else}
-                        Bara roșie e ultima încercare. <strong>Mai înalt = mai lent.</strong> Versetele lungi
-                        apar în mod natural ca bare mai înalte.
+                        Barele sunt ultima încercare. <strong>Mai înalt = mai lent.</strong>
+                        <span class="legend-color">🟢 verde = cel mai rapid verset (timp mic), 🔴 roșu = cel mai lent</span>.
+                        Versetele lungi apar în mod natural ca bare mai înalte.
                     {/if}
                     Bifează încercări din listă pentru a le compara.
                 </p>
@@ -189,7 +191,11 @@
                                             on:change={() => toggleSelected(run.id)}
                                         />
                                         {#if selectedIds.has(run.id)}
-                                            <span class="swatch" style="background: {colorFor(run.id)}"></span>
+                                            {#if i === 0}
+                                                <span class="swatch swatch-gradient" title="Gradient: roșu = mai slab, verde = mai bun"></span>
+                                            {:else}
+                                                <span class="swatch" style="background: {colorFor(run.id)}"></span>
+                                            {/if}
                                         {/if}
                                     </label>
                                 </td>
@@ -333,6 +339,15 @@
         height: 12px;
         border-radius: 2px;
         border: 1px solid rgba(0, 0, 0, 0.15);
+    }
+    .swatch-gradient {
+        width: 28px;
+        background: linear-gradient(
+            to right,
+            hsl(0, 75%, 50%),
+            hsl(60, 75%, 50%),
+            hsl(120, 75%, 50%)
+        );
     }
     button.small {
         font-size: 0.85em;

--- a/src/components/RunHistory.svelte
+++ b/src/components/RunHistory.svelte
@@ -143,11 +143,11 @@
                 </div>
                 <p class="hint">
                     {#if metric === 'wpm'}
-                        Barele sunt ultima încercare. <strong>Mai înalt = mai rapid.</strong>
+                        Barele reprezintă cea mai recentă încercare din cele bifate. <strong>Mai înalt = mai rapid.</strong>
                         <span class="legend-color">🟢 verde = cel mai rapid verset, 🔴 roșu = cel mai lent</span>.
                         Lungimea versetului este normalizată, așa că un verset lung dar tipărit rapid nu mai arată „lent”.
                     {:else}
-                        Barele sunt ultima încercare. <strong>Mai înalt = mai lent.</strong>
+                        Barele reprezintă cea mai recentă încercare din cele bifate. <strong>Mai înalt = mai lent.</strong>
                         <span class="legend-color">🟢 verde = cel mai rapid verset (timp mic), 🔴 roșu = cel mai lent</span>.
                         Versetele lungi apar în mod natural ca bare mai înalte.
                     {/if}
@@ -191,7 +191,7 @@
                                             on:change={() => toggleSelected(run.id)}
                                         />
                                         {#if selectedIds.has(run.id)}
-                                            {#if i === 0}
+                                            {#if chartedRuns[0] && chartedRuns[0].id === run.id}
                                                 <span class="swatch swatch-gradient" title="Gradient: roșu = mai slab, verde = mai bun"></span>
                                             {:else}
                                                 <span class="swatch" style="background: {colorFor(run.id)}"></span>

--- a/src/components/RunHistory.svelte
+++ b/src/components/RunHistory.svelte
@@ -71,6 +71,20 @@
         return picked;
     })();
 
+    // Stable signature so swatches re-render when the charted set or order changes.
+    $: chartedRunIds = chartedRuns.map((r) => r.id).join('|');
+
+    // Legend swatch per run id — must stay in sync with PerVerseChart series colours:
+    // index 0 = gradient bars; index 1+ = palette[that index] dashed line.
+    $: swatchById = (() => {
+        /** @type {Record<string, string>} */
+        const m = {};
+        chartedRuns.forEach((r, i) => {
+            m[r.id] = i === 0 ? 'gradient' : palette[i % palette.length];
+        });
+        return m;
+    })();
+
     function toggleSelected(id) {
         const next = new Set(selectedIds);
         if (next.has(id)) next.delete(id);
@@ -96,12 +110,6 @@
         if (!confirm('Sigur vrei să ștergi tot istoricul pentru această rundă?')) return;
         clearRound(round);
         selectedIds = new Set();
-    }
-
-    function colorFor(id) {
-        const idx = chartedRuns.findIndex((r) => r.id === id);
-        if (idx < 0) return '#999';
-        return palette[idx % palette.length];
     }
 
     function formatDelta(run) {
@@ -191,11 +199,13 @@
                                             on:change={() => toggleSelected(run.id)}
                                         />
                                         {#if selectedIds.has(run.id)}
-                                            {#if chartedRuns[0] && chartedRuns[0].id === run.id}
-                                                <span class="swatch swatch-gradient" title="Gradient: roșu = mai slab, verde = mai bun"></span>
-                                            {:else}
-                                                <span class="swatch" style="background: {colorFor(run.id)}"></span>
-                                            {/if}
+                                            {#key chartedRunIds}
+                                                {#if swatchById[run.id] === 'gradient'}
+                                                    <span class="swatch swatch-gradient" title="Gradient: roșu = mai slab, verde = mai bun"></span>
+                                                {:else if swatchById[run.id]}
+                                                    <span class="swatch" style="background: {swatchById[run.id]}"></span>
+                                                {/if}
+                                            {/key}
                                         {/if}
                                     </label>
                                 </td>

--- a/src/components/SequentialTraining.svelte
+++ b/src/components/SequentialTraining.svelte
@@ -144,6 +144,14 @@
 {#if eligibleForScoring && verseIdx == crtChapter.length}
     <ScoreSubmitForm score={elapsedTime} {round} resetSignal={scoreResetSignal} />
 {/if}
+{#if competitiveMode && round}
+    <RunHistory
+        round={round}
+        title={`Istoric pentru ${bookName} - Capitolul ${chapterIdx + 1}`}
+        verseLabels={crtChapter.map((_, i) => String(rollingSumVerseIdx + i + 1))}
+        highlightRunId={lastSavedRunId}
+    />
+{/if}
 <button on:click={jumpToChapter(chapterIdx)}>
     Resetează capitolul
 </button>

--- a/src/components/SequentialTraining.svelte
+++ b/src/components/SequentialTraining.svelte
@@ -2,7 +2,9 @@
     import VersesInput from '/src/components/VersesInput.svelte';
     import WrittenText from '/src/components/WrittenText.svelte';
     import ScoreSubmitForm from '/src/components/ScoreSubmitForm.svelte';
+    import RunHistory from '/src/components/RunHistory.svelte';
     import { createStopwatch } from '/src/lib/stopwatch.js';
+    import { saveRun } from '/src/lib/runHistory.js';
 
     export let bookName;
     export let chapters;
@@ -78,8 +80,11 @@
     const stopwatchState = stopwatch.state;
     $: timerStarted = $stopwatchState.hasStarted;
     $: elapsedTime = $stopwatchState.elapsedTime;
+    $: splits = $stopwatchState.splits;
 
     let previousCompetitionResetSignal = competitionResetSignal;
+    let runSavedForThisAttempt = false;
+    let lastSavedRunId = '';
 
     $: if (competitionResetSignal !== previousCompetitionResetSignal) {
         previousCompetitionResetSignal = competitionResetSignal;
@@ -94,11 +99,33 @@
 
     $: if (!timerStarted && competitiveMode && discoveredVerseText.length > 0) {
         eligibleForScoring = competitiveMode;
+        runSavedForThisAttempt = false;
         stopwatch.start();
     }
 
     $: if (timerStarted && verseIdx == crtChapter.length) {
         stopwatch.stop();
+        if (eligibleForScoring && !runSavedForThisAttempt && round) {
+            runSavedForThisAttempt = true;
+            const verseLabels = crtChapter.map((_, i) => String(rollingSumVerseIdx + i + 1));
+            const saved = saveRun({
+                round,
+                totalTime: elapsedTime,
+                verseTimes: splits.slice(0, crtChapter.length),
+                verseLabels
+            });
+            if (saved) {
+                lastSavedRunId = saved.id;
+            }
+        }
+    }
+
+    function handleVerseDone() {
+        if (competitiveMode) {
+            stopwatch.split();
+        }
+        verseIdx++;
+        discoveredVerseText = '';
     }
 
     function resetChapter() {
@@ -107,6 +134,7 @@
         verseIdx = start.verse - 1;
         discoveredVerseText = '';
         eligibleForScoring = false;
+        runSavedForThisAttempt = false;
         resetVersesInput();
     }
 </script>
@@ -115,7 +143,7 @@
 <WrittenText startIdx={rollingSumVerseIdx+start.verse} verses={crtChapter.slice(start.verse-1, verseIdx).concat(verseIdx < crtChapter.length ? [discoveredVerseText] : [])}></WrittenText>
 <br>
 {#key crtVerse}
-    <VersesInput inputText={crtVerse} fnVerseDone={() => {verseIdx++; discoveredVerseText = ''}} bind:discoveredText={discoveredVerseText} disableNextButton={competitiveMode} bind:reset={resetVersesInput}></VersesInput>
+    <VersesInput inputText={crtVerse} fnVerseDone={handleVerseDone} bind:discoveredText={discoveredVerseText} disableNextButton={competitiveMode} bind:reset={resetVersesInput}></VersesInput>
 {/key}
 <br>
 <br>

--- a/src/components/SequentialTraining.svelte
+++ b/src/components/SequentialTraining.svelte
@@ -5,6 +5,7 @@
     import RunHistory from '/src/components/RunHistory.svelte';
     import { createStopwatch } from '/src/lib/stopwatch.js';
     import { saveRun } from '/src/lib/runHistory.js';
+    import { countWords } from '/src/lib/verseWords.js';
 
     export let bookName;
     export let chapters;
@@ -86,6 +87,9 @@
     let runSavedForThisAttempt = false;
     let lastSavedRunId = '';
 
+    $: chapterVerseLabels = crtChapter.map((_, i) => String(rollingSumVerseIdx + i + 1));
+    $: chapterVerseWordCounts = crtChapter.map((v) => countWords(v));
+
     $: if (competitionResetSignal !== previousCompetitionResetSignal) {
         previousCompetitionResetSignal = competitionResetSignal;
         resetChapter();
@@ -107,12 +111,12 @@
         stopwatch.stop();
         if (eligibleForScoring && !runSavedForThisAttempt && round) {
             runSavedForThisAttempt = true;
-            const verseLabels = crtChapter.map((_, i) => String(rollingSumVerseIdx + i + 1));
             const saved = saveRun({
                 round,
                 totalTime: elapsedTime,
                 verseTimes: splits.slice(0, crtChapter.length),
-                verseLabels
+                verseLabels: chapterVerseLabels,
+                verseWordCounts: chapterVerseWordCounts
             });
             if (saved) {
                 lastSavedRunId = saved.id;
@@ -176,7 +180,8 @@
     <RunHistory
         round={round}
         title={`Istoric pentru ${bookName} - Capitolul ${chapterIdx + 1}`}
-        verseLabels={crtChapter.map((_, i) => String(rollingSumVerseIdx + i + 1))}
+        verseLabels={chapterVerseLabels}
+        verseWordCounts={chapterVerseWordCounts}
         highlightRunId={lastSavedRunId}
     />
 {/if}

--- a/src/components/charts/PerVerseChart.svelte
+++ b/src/components/charts/PerVerseChart.svelte
@@ -1,0 +1,230 @@
+<script>
+    // @ts-nocheck
+
+    /**
+     * Renders a multi-series chart of per-verse times for one or more runs.
+     * Each run is shown as a colored polyline + dots, and the most-recent
+     * run is also rendered as filled bars in the background so it is easy
+     * to see which segments of the chapter are slow.
+     */
+
+    export let runs = [];
+    export let verseLabels = [];
+
+    const palette = [
+        '#e15759', // current run / red
+        '#4e79a7', // blue
+        '#f28e2b', // orange
+        '#76b7b2', // teal
+        '#59a14f', // green
+        '#edc948', // yellow
+        '#b07aa1', // purple
+        '#ff9da7', // pink
+        '#9c755f', // brown
+        '#bab0ac'  // gray
+    ];
+
+    let hoverIdx = -1;
+
+    $: maxVerses = Math.max(0, ...runs.map((r) => (r && r.verseTimes ? r.verseTimes.length : 0)));
+    $: maxTime = (() => {
+        let m = 0;
+        for (const r of runs) {
+            if (!r || !r.verseTimes) continue;
+            for (const t of r.verseTimes) if (t > m) m = t;
+        }
+        return m === 0 ? 1 : m;
+    })();
+
+    // Axis ticks for Y
+    function niceCeil(v) {
+        if (v <= 0) return 1;
+        const pow = Math.pow(10, Math.floor(Math.log10(v)));
+        const n = v / pow;
+        let nice;
+        if (n <= 1) nice = 1;
+        else if (n <= 2) nice = 2;
+        else if (n <= 5) nice = 5;
+        else nice = 10;
+        return nice * pow;
+    }
+    $: yMax = niceCeil(maxTime * 1.05);
+    $: yTicks = (() => {
+        const ticks = [];
+        const steps = 5;
+        for (let i = 0; i <= steps; i++) ticks.push((yMax * i) / steps);
+        return ticks;
+    })();
+
+    // Chart geometry
+    const width = 720;
+    const height = 320;
+    const margin = { top: 16, right: 16, bottom: 56, left: 48 };
+    $: innerW = width - margin.left - margin.right;
+    $: innerH = height - margin.top - margin.bottom;
+
+    $: xStep = maxVerses > 0 ? innerW / maxVerses : 0;
+
+    function xCenter(i) {
+        return margin.left + xStep * (i + 0.5);
+    }
+    function yPos(v) {
+        return margin.top + innerH - (v / yMax) * innerH;
+    }
+
+    function labelFor(i) {
+        if (verseLabels && verseLabels[i]) return verseLabels[i];
+        return String(i + 1);
+    }
+
+    function polylinePoints(verseTimes) {
+        return verseTimes
+            .map((t, i) => `${xCenter(i)},${yPos(t)}`)
+            .join(' ');
+    }
+
+    // Pick a label rotation when there are many bars
+    $: rotateLabels = maxVerses > 12;
+</script>
+
+{#if runs.length === 0 || maxVerses === 0}
+    <p><em>Nu există date pentru grafic.</em></p>
+{:else}
+    <div class="chart-wrap">
+        <svg viewBox="0 0 {width} {height}" preserveAspectRatio="xMidYMid meet" class="chart">
+            <!-- Y grid + ticks -->
+            {#each yTicks as t}
+                <line
+                    x1={margin.left}
+                    x2={margin.left + innerW}
+                    y1={yPos(t)}
+                    y2={yPos(t)}
+                    class="grid"
+                />
+                <text x={margin.left - 6} y={yPos(t)} class="tick" text-anchor="end" dominant-baseline="middle">
+                    {t.toFixed(1)}s
+                </text>
+            {/each}
+
+            <!-- Bars for the most recent run (runs[0]) -->
+            {#if runs[0]}
+                {#each runs[0].verseTimes as t, i}
+                    <rect
+                        x={margin.left + xStep * i + xStep * 0.18}
+                        y={yPos(t)}
+                        width={Math.max(1, xStep * 0.64)}
+                        height={Math.max(0, margin.top + innerH - yPos(t))}
+                        class="bar"
+                        class:hover={hoverIdx === i}
+                        on:mouseenter={() => (hoverIdx = i)}
+                        on:mouseleave={() => (hoverIdx = -1)}
+                    >
+                        <title>{labelFor(i)}: {t.toFixed(2)}s</title>
+                    </rect>
+                {/each}
+            {/if}
+
+            <!-- Polylines for every selected run -->
+            {#each runs as run, ri}
+                {#if run && run.verseTimes && run.verseTimes.length > 0}
+                    <polyline
+                        points={polylinePoints(run.verseTimes)}
+                        fill="none"
+                        stroke={palette[ri % palette.length]}
+                        stroke-width={ri === 0 ? 2.5 : 1.5}
+                        stroke-opacity={ri === 0 ? 1 : 0.85}
+                        stroke-dasharray={ri === 0 ? '' : '4 3'}
+                    />
+                    {#each run.verseTimes as t, i}
+                        <circle
+                            cx={xCenter(i)}
+                            cy={yPos(t)}
+                            r={ri === 0 ? 3.5 : 2.5}
+                            fill={palette[ri % palette.length]}
+                        >
+                            <title>{labelFor(i)}: {t.toFixed(2)}s</title>
+                        </circle>
+                    {/each}
+                {/if}
+            {/each}
+
+            <!-- X axis labels -->
+            {#each Array(maxVerses) as _, i}
+                <text
+                    x={xCenter(i)}
+                    y={margin.top + innerH + (rotateLabels ? 10 : 16)}
+                    class="tick"
+                    text-anchor={rotateLabels ? 'end' : 'middle'}
+                    transform={rotateLabels ? `rotate(-45 ${xCenter(i)} ${margin.top + innerH + 10})` : ''}
+                >
+                    {labelFor(i)}
+                </text>
+            {/each}
+
+            <!-- Axes -->
+            <line x1={margin.left} x2={margin.left + innerW} y1={margin.top + innerH} y2={margin.top + innerH} class="axis" />
+            <line x1={margin.left} x2={margin.left} y1={margin.top} y2={margin.top + innerH} class="axis" />
+
+            <!-- Axis titles -->
+            <text x={margin.left + innerW / 2} y={height - 4} class="axis-title" text-anchor="middle">Verset</text>
+            <text
+                x={-(margin.top + innerH / 2)}
+                y={12}
+                class="axis-title"
+                text-anchor="middle"
+                transform="rotate(-90)"
+            >Secunde</text>
+        </svg>
+    </div>
+{/if}
+
+<style>
+    .chart-wrap {
+        width: 100%;
+        max-width: 760px;
+    }
+    .chart {
+        width: 100%;
+        height: auto;
+        font-family: inherit;
+    }
+    .grid {
+        stroke: #d0d0d0;
+        stroke-width: 1;
+        stroke-dasharray: 2 2;
+    }
+    .axis {
+        stroke: #8a8a8a;
+        stroke-width: 1;
+    }
+    .bar {
+        fill: rgba(225, 87, 89, 0.18);
+        stroke: rgba(225, 87, 89, 0.45);
+        stroke-width: 1;
+        transition: fill 0.15s ease;
+    }
+    .bar.hover {
+        fill: rgba(225, 87, 89, 0.4);
+    }
+    .tick {
+        fill: #555;
+        font-size: 11px;
+    }
+    .axis-title {
+        fill: #444;
+        font-size: 12px;
+        font-weight: bold;
+    }
+    :global(body.dark-mode) .grid {
+        stroke: #2c3a4a;
+    }
+    :global(body.dark-mode) .axis {
+        stroke: #6a7c92;
+    }
+    :global(body.dark-mode) .tick {
+        fill: #b9c3cf;
+    }
+    :global(body.dark-mode) .axis-title {
+        fill: #d7d7d7;
+    }
+</style>

--- a/src/components/charts/PerVerseChart.svelte
+++ b/src/components/charts/PerVerseChart.svelte
@@ -11,8 +11,9 @@
      *                because there are more words to type.
      *  - 'seconds' — raw time per verse. Lower bars = faster.
      *
-     * The most-recent run is rendered as filled bars in the background and
-     * a thick polyline; other selected runs are dashed polylines.
+     * The most-recent run is rendered as filled bars (colour-coded by
+     * per-verse "goodness": green = best, red = worst) plus a polyline.
+     * Other selected runs are dashed polylines in palette colours.
      */
 
     export let runs = [];
@@ -61,8 +62,6 @@
         return String(i + 1);
     }
 
-    // Build the rendered series fully reactively so any change to runs /
-    // metric / verseWordCounts forces a re-render.
     $: series = runs.map((run, ri) => {
         if (!run || !run.verseTimes) return null;
         const points = run.verseTimes.map((_, i) => {
@@ -88,37 +87,67 @@
         return vals;
     })();
 
-    // Robust Y-axis upper bound — protects against single outliers.
-    $: maxValue = (() => {
-        if (allValues.length === 0) return 1;
-        const sorted = [...allValues].sort((a, b) => a - b);
-        const median = sorted[Math.floor(sorted.length / 2)] || 1;
-        const p90Idx = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.9));
-        const p90 = sorted[p90Idx] || median;
-        const peak = sorted[sorted.length - 1] || median;
-        const robust = Math.max(median * 4, p90 * 1.15, 1);
-        if (peak <= robust * 1.5) return Math.max(robust, peak);
-        return robust;
-    })();
-
-    function niceCeil(v) {
-        if (v <= 0) return 1;
-        const pow = Math.pow(10, Math.floor(Math.log10(v)));
-        const n = v / pow;
+    // Tight Y-axis bound: pick a "nice" tick step around max/5, ceil max to a
+    // multiple of that step. Avoids the huge whitespace caused by the old
+    // robust scaling while still producing readable tick labels.
+    function niceTickStep(rough) {
+        if (rough <= 0) return 1;
+        const pow = Math.pow(10, Math.floor(Math.log10(rough)));
+        const norm = rough / pow;
         let nice;
-        if (n <= 1) nice = 1;
-        else if (n <= 2) nice = 2;
-        else if (n <= 5) nice = 5;
+        if (norm < 1.5) nice = 1;
+        else if (norm < 3) nice = 2;
+        else if (norm < 7) nice = 5;
         else nice = 10;
         return nice * pow;
     }
-    $: yMax = niceCeil(maxValue * 1.05);
-    $: yTicks = (() => {
+
+    $: maxValue = allValues.length > 0 ? Math.max(...allValues) : 1;
+    $: yAxis = (() => {
+        if (maxValue <= 0) return { yMax: 1, ticks: [0, 1] };
+        const step = niceTickStep(maxValue / 5);
+        const yMax = Math.ceil(maxValue / step) * step;
         const ticks = [];
-        const steps = 5;
-        for (let i = 0; i <= steps; i++) ticks.push((yMax * i) / steps);
-        return ticks;
+        for (let v = 0; v <= yMax + step / 2; v += step) ticks.push(v);
+        return { yMax, ticks, step };
     })();
+    $: yMax = yAxis.yMax;
+    $: yTicks = yAxis.ticks;
+
+    // --- Per-bar colour coding (latest run only) ---
+    $: latestValueRange = (() => {
+        if (!series[0]) return { min: 0, max: 0 };
+        const vals = series[0].points.map((p) => p.value).filter((v) => v !== null && isFinite(v));
+        if (vals.length === 0) return { min: 0, max: 0 };
+        return { min: Math.min(...vals), max: Math.max(...vals) };
+    })();
+
+    function goodnessFor(value) {
+        if (value === null || !isFinite(value)) return 0.5;
+        const { min, max } = latestValueRange;
+        if (max <= min) return 0.5;
+        const t = (value - min) / (max - min);
+        return effectiveMetric === 'wpm' ? t : 1 - t;
+    }
+
+    function barFill(value) {
+        if (value === null) return 'rgba(150,150,150,0.15)';
+        const g = goodnessFor(value);
+        const hue = 120 * g;
+        return `hsla(${hue}, 75%, 50%, 0.55)`;
+    }
+    function barStroke(value) {
+        if (value === null) return 'rgba(150,150,150,0.3)';
+        const g = goodnessFor(value);
+        const hue = 120 * g;
+        return `hsl(${hue}, 75%, 35%)`;
+    }
+    function dotColor(value) {
+        if (value === null) return '#999';
+        const g = goodnessFor(value);
+        const hue = 120 * g;
+        return `hsl(${hue}, 75%, 35%)`;
+    }
 
     const width = 720;
     const height = 320;
@@ -140,7 +169,7 @@
 
     $: yTickFormatter = effectiveMetric === 'wpm'
         ? (t) => `${t.toFixed(0)}`
-        : (t) => `${t.toFixed(1)}s`;
+        : (t) => (t >= 10 ? `${t.toFixed(0)}s` : `${t.toFixed(1)}s`);
     $: yAxisTitle = effectiveMetric === 'wpm' ? 'Cuvinte / minut' : 'Secunde';
 
     function polylinePoints(points) {
@@ -179,6 +208,9 @@
                             y={yPos(p.value)}
                             width={Math.max(1, xStep * 0.64)}
                             height={Math.max(0, margin.top + innerH - yPos(p.value))}
+                            fill={barFill(p.value)}
+                            stroke={barStroke(p.value)}
+                            stroke-width="1"
                             class="bar"
                             class:hover={hoverIdx === p.idx}
                             on:mouseenter={() => (hoverIdx = p.idx)}
@@ -191,27 +223,46 @@
             {/if}
 
             {#each series as s, ri (s.runId)}
-                <polyline
-                    points={polylinePoints(s.points)}
-                    fill="none"
-                    stroke={s.color}
-                    stroke-width={s.isLatest ? 2.5 : 1.5}
-                    stroke-opacity={s.isLatest ? 1 : 0.85}
-                    stroke-dasharray={s.isLatest ? '' : '4 3'}
-                />
-                {#each s.points as p (p.idx)}
+                {#if !s.isLatest}
+                    <polyline
+                        points={polylinePoints(s.points)}
+                        fill="none"
+                        stroke={s.color}
+                        stroke-width="1.5"
+                        stroke-opacity="0.85"
+                        stroke-dasharray="4 3"
+                    />
+                    {#each s.points as p (p.idx)}
+                        {#if p.value !== null}
+                            <circle
+                                cx={xCenter(p.idx)}
+                                cy={yPos(p.value)}
+                                r="2.5"
+                                fill={s.color}
+                            >
+                                <title>{p.tooltip}</title>
+                            </circle>
+                        {/if}
+                    {/each}
+                {/if}
+            {/each}
+
+            {#if series[0]}
+                {#each series[0].points as p (p.idx)}
                     {#if p.value !== null}
                         <circle
                             cx={xCenter(p.idx)}
                             cy={yPos(p.value)}
-                            r={s.isLatest ? 3.5 : 2.5}
-                            fill={s.color}
+                            r="3.5"
+                            fill={dotColor(p.value)}
+                            stroke="#fff"
+                            stroke-width="1"
                         >
                             <title>{p.tooltip}</title>
                         </circle>
                     {/if}
                 {/each}
-            {/each}
+            {/if}
 
             {#each Array(maxVerses) as _, i}
                 <text
@@ -260,13 +311,10 @@
         stroke-width: 1;
     }
     .bar {
-        fill: rgba(225, 87, 89, 0.18);
-        stroke: rgba(225, 87, 89, 0.45);
-        stroke-width: 1;
-        transition: fill 0.15s ease;
+        transition: filter 0.15s ease;
     }
     .bar.hover {
-        fill: rgba(225, 87, 89, 0.4);
+        filter: brightness(0.85);
     }
     .tick {
         fill: #555;
@@ -288,5 +336,8 @@
     }
     :global(body.dark-mode) .axis-title {
         fill: #d7d7d7;
+    }
+    :global(body.dark-mode) .bar.hover {
+        filter: brightness(1.15);
     }
 </style>

--- a/src/components/charts/PerVerseChart.svelte
+++ b/src/components/charts/PerVerseChart.svelte
@@ -3,40 +3,104 @@
 
     /**
      * Renders a multi-series chart of per-verse times for one or more runs.
-     * Each run is shown as a colored polyline + dots, and the most-recent
-     * run is also rendered as filled bars in the background so it is easy
-     * to see which segments of the chapter are slow.
+     *
+     * Two metrics are supported:
+     *  - 'wpm'     — words per minute (verseWordCounts[i] / verseTimes[i] * 60).
+     *                Higher bars = faster. Verse length is normalised out,
+     *                which is what we want when long verses look slow simply
+     *                because there are more words to type.
+     *  - 'seconds' — raw time per verse. Lower bars = faster.
+     *
+     * The most-recent run is rendered as filled bars in the background and
+     * a thick polyline; other selected runs are dashed polylines.
      */
 
     export let runs = [];
     export let verseLabels = [];
+    /** @type {number[]} */
+    export let verseWordCounts = [];
+    /** @type {'wpm' | 'seconds'} */
+    export let metric = 'wpm';
 
     const palette = [
-        '#e15759', // current run / red
-        '#4e79a7', // blue
-        '#f28e2b', // orange
-        '#76b7b2', // teal
-        '#59a14f', // green
-        '#edc948', // yellow
-        '#b07aa1', // purple
-        '#ff9da7', // pink
-        '#9c755f', // brown
-        '#bab0ac'  // gray
+        '#e15759', '#4e79a7', '#f28e2b', '#76b7b2',
+        '#59a14f', '#edc948', '#b07aa1', '#ff9da7',
+        '#9c755f', '#bab0ac'
     ];
 
     let hoverIdx = -1;
 
-    $: maxVerses = Math.max(0, ...runs.map((r) => (r && r.verseTimes ? r.verseTimes.length : 0)));
-    $: maxTime = (() => {
-        let m = 0;
-        for (const r of runs) {
-            if (!r || !r.verseTimes) continue;
-            for (const t of r.verseTimes) if (t > m) m = t;
+    $: effectiveMetric = (metric === 'wpm' && verseWordCounts && verseWordCounts.length > 0)
+        ? 'wpm'
+        : 'seconds';
+
+    function computeValue(verseTimes, i, m, wc) {
+        const t = verseTimes[i];
+        if (t === undefined || t === null) return null;
+        if (m === 'wpm') {
+            const w = wc && wc[i];
+            if (!w || t <= 0) return null;
+            return (w / t) * 60;
         }
-        return m === 0 ? 1 : m;
+        return t;
+    }
+
+    function computeTooltip(verseTimes, i, m, wc, label) {
+        const t = verseTimes[i];
+        const w = wc && wc[i];
+        const v = computeValue(verseTimes, i, m, wc);
+        if (v === null) return `${label}: -`;
+        if (m === 'wpm') {
+            return `${label}: ${v.toFixed(1)} cuv/min (${(t || 0).toFixed(2)}s, ${w} cuv)`;
+        }
+        return `${label}: ${(t || 0).toFixed(2)}s`;
+    }
+
+    function labelFor(i) {
+        if (verseLabels && verseLabels[i]) return verseLabels[i];
+        return String(i + 1);
+    }
+
+    // Build the rendered series fully reactively so any change to runs /
+    // metric / verseWordCounts forces a re-render.
+    $: series = runs.map((run, ri) => {
+        if (!run || !run.verseTimes) return null;
+        const points = run.verseTimes.map((_, i) => {
+            const v = computeValue(run.verseTimes, i, effectiveMetric, verseWordCounts);
+            return {
+                idx: i,
+                value: v,
+                tooltip: computeTooltip(run.verseTimes, i, effectiveMetric, verseWordCounts, labelFor(i))
+            };
+        });
+        return { runId: run.id || ri, color: palette[ri % palette.length], isLatest: ri === 0, points };
+    }).filter((s) => s !== null);
+
+    $: maxVerses = Math.max(0, ...series.map((s) => s.points.length));
+
+    $: allValues = (() => {
+        const vals = [];
+        for (const s of series) {
+            for (const p of s.points) {
+                if (p.value !== null && isFinite(p.value)) vals.push(p.value);
+            }
+        }
+        return vals;
     })();
 
-    // Axis ticks for Y
+    // Robust Y-axis upper bound — protects against single outliers.
+    $: maxValue = (() => {
+        if (allValues.length === 0) return 1;
+        const sorted = [...allValues].sort((a, b) => a - b);
+        const median = sorted[Math.floor(sorted.length / 2)] || 1;
+        const p90Idx = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.9));
+        const p90 = sorted[p90Idx] || median;
+        const peak = sorted[sorted.length - 1] || median;
+        const robust = Math.max(median * 4, p90 * 1.15, 1);
+        if (peak <= robust * 1.5) return Math.max(robust, peak);
+        return robust;
+    })();
+
     function niceCeil(v) {
         if (v <= 0) return 1;
         const pow = Math.pow(10, Math.floor(Math.log10(v)));
@@ -48,7 +112,7 @@
         else nice = 10;
         return nice * pow;
     }
-    $: yMax = niceCeil(maxTime * 1.05);
+    $: yMax = niceCeil(maxValue * 1.05);
     $: yTicks = (() => {
         const ticks = [];
         const steps = 5;
@@ -56,10 +120,9 @@
         return ticks;
     })();
 
-    // Chart geometry
     const width = 720;
     const height = 320;
-    const margin = { top: 16, right: 16, bottom: 56, left: 48 };
+    const margin = { top: 16, right: 16, bottom: 56, left: 56 };
     $: innerW = width - margin.left - margin.right;
     $: innerH = height - margin.top - margin.bottom;
 
@@ -69,30 +132,32 @@
         return margin.left + xStep * (i + 0.5);
     }
     function yPos(v) {
-        return margin.top + innerH - (v / yMax) * innerH;
+        const clamped = Math.min(v, yMax);
+        return margin.top + innerH - (clamped / yMax) * innerH;
     }
 
-    function labelFor(i) {
-        if (verseLabels && verseLabels[i]) return verseLabels[i];
-        return String(i + 1);
-    }
-
-    function polylinePoints(verseTimes) {
-        return verseTimes
-            .map((t, i) => `${xCenter(i)},${yPos(t)}`)
-            .join(' ');
-    }
-
-    // Pick a label rotation when there are many bars
     $: rotateLabels = maxVerses > 12;
+
+    $: yTickFormatter = effectiveMetric === 'wpm'
+        ? (t) => `${t.toFixed(0)}`
+        : (t) => `${t.toFixed(1)}s`;
+    $: yAxisTitle = effectiveMetric === 'wpm' ? 'Cuvinte / minut' : 'Secunde';
+
+    function polylinePoints(points) {
+        const pts = [];
+        for (const p of points) {
+            if (p.value === null) continue;
+            pts.push(`${xCenter(p.idx)},${yPos(p.value)}`);
+        }
+        return pts.join(' ');
+    }
 </script>
 
-{#if runs.length === 0 || maxVerses === 0}
+{#if series.length === 0 || maxVerses === 0}
     <p><em>Nu există date pentru grafic.</em></p>
 {:else}
     <div class="chart-wrap">
         <svg viewBox="0 0 {width} {height}" preserveAspectRatio="xMidYMid meet" class="chart">
-            <!-- Y grid + ticks -->
             {#each yTicks as t}
                 <line
                     x1={margin.left}
@@ -102,53 +167,52 @@
                     class="grid"
                 />
                 <text x={margin.left - 6} y={yPos(t)} class="tick" text-anchor="end" dominant-baseline="middle">
-                    {t.toFixed(1)}s
+                    {yTickFormatter(t)}
                 </text>
             {/each}
 
-            <!-- Bars for the most recent run (runs[0]) -->
-            {#if runs[0]}
-                {#each runs[0].verseTimes as t, i}
-                    <rect
-                        x={margin.left + xStep * i + xStep * 0.18}
-                        y={yPos(t)}
-                        width={Math.max(1, xStep * 0.64)}
-                        height={Math.max(0, margin.top + innerH - yPos(t))}
-                        class="bar"
-                        class:hover={hoverIdx === i}
-                        on:mouseenter={() => (hoverIdx = i)}
-                        on:mouseleave={() => (hoverIdx = -1)}
-                    >
-                        <title>{labelFor(i)}: {t.toFixed(2)}s</title>
-                    </rect>
+            {#if series[0]}
+                {#each series[0].points as p (p.idx)}
+                    {#if p.value !== null}
+                        <rect
+                            x={margin.left + xStep * p.idx + xStep * 0.18}
+                            y={yPos(p.value)}
+                            width={Math.max(1, xStep * 0.64)}
+                            height={Math.max(0, margin.top + innerH - yPos(p.value))}
+                            class="bar"
+                            class:hover={hoverIdx === p.idx}
+                            on:mouseenter={() => (hoverIdx = p.idx)}
+                            on:mouseleave={() => (hoverIdx = -1)}
+                        >
+                            <title>{p.tooltip}</title>
+                        </rect>
+                    {/if}
                 {/each}
             {/if}
 
-            <!-- Polylines for every selected run -->
-            {#each runs as run, ri}
-                {#if run && run.verseTimes && run.verseTimes.length > 0}
-                    <polyline
-                        points={polylinePoints(run.verseTimes)}
-                        fill="none"
-                        stroke={palette[ri % palette.length]}
-                        stroke-width={ri === 0 ? 2.5 : 1.5}
-                        stroke-opacity={ri === 0 ? 1 : 0.85}
-                        stroke-dasharray={ri === 0 ? '' : '4 3'}
-                    />
-                    {#each run.verseTimes as t, i}
+            {#each series as s, ri (s.runId)}
+                <polyline
+                    points={polylinePoints(s.points)}
+                    fill="none"
+                    stroke={s.color}
+                    stroke-width={s.isLatest ? 2.5 : 1.5}
+                    stroke-opacity={s.isLatest ? 1 : 0.85}
+                    stroke-dasharray={s.isLatest ? '' : '4 3'}
+                />
+                {#each s.points as p (p.idx)}
+                    {#if p.value !== null}
                         <circle
-                            cx={xCenter(i)}
-                            cy={yPos(t)}
-                            r={ri === 0 ? 3.5 : 2.5}
-                            fill={palette[ri % palette.length]}
+                            cx={xCenter(p.idx)}
+                            cy={yPos(p.value)}
+                            r={s.isLatest ? 3.5 : 2.5}
+                            fill={s.color}
                         >
-                            <title>{labelFor(i)}: {t.toFixed(2)}s</title>
+                            <title>{p.tooltip}</title>
                         </circle>
-                    {/each}
-                {/if}
+                    {/if}
+                {/each}
             {/each}
 
-            <!-- X axis labels -->
             {#each Array(maxVerses) as _, i}
                 <text
                     x={xCenter(i)}
@@ -161,11 +225,9 @@
                 </text>
             {/each}
 
-            <!-- Axes -->
             <line x1={margin.left} x2={margin.left + innerW} y1={margin.top + innerH} y2={margin.top + innerH} class="axis" />
             <line x1={margin.left} x2={margin.left} y1={margin.top} y2={margin.top + innerH} class="axis" />
 
-            <!-- Axis titles -->
             <text x={margin.left + innerW / 2} y={height - 4} class="axis-title" text-anchor="middle">Verset</text>
             <text
                 x={-(margin.top + innerH / 2)}
@@ -173,7 +235,7 @@
                 class="axis-title"
                 text-anchor="middle"
                 transform="rotate(-90)"
-            >Secunde</text>
+            >{yAxisTitle}</text>
         </svg>
     </div>
 {/if}

--- a/src/components/charts/TotalTimeChart.svelte
+++ b/src/components/charts/TotalTimeChart.svelte
@@ -1,0 +1,174 @@
+<script>
+    // @ts-nocheck
+
+    /**
+     * Renders the trend of total run time over time.
+     * Runs are plotted in chronological order on the X axis (oldest to newest)
+     * and total time on the Y axis.
+     */
+    export let runs = [];
+    export let highlightId = '';
+
+    $: chrono = [...runs].sort((a, b) => a.timestamp - b.timestamp);
+
+    function niceCeil(v) {
+        if (v <= 0) return 1;
+        const pow = Math.pow(10, Math.floor(Math.log10(v)));
+        const n = v / pow;
+        let nice;
+        if (n <= 1) nice = 1;
+        else if (n <= 2) nice = 2;
+        else if (n <= 5) nice = 5;
+        else nice = 10;
+        return nice * pow;
+    }
+
+    $: maxTotal = chrono.reduce((m, r) => Math.max(m, r.totalTime || 0), 0);
+    $: yMax = niceCeil(Math.max(1, maxTotal * 1.05));
+    $: yTicks = (() => {
+        const ticks = [];
+        const steps = 5;
+        for (let i = 0; i <= steps; i++) ticks.push((yMax * i) / steps);
+        return ticks;
+    })();
+
+    const width = 720;
+    const height = 240;
+    const margin = { top: 16, right: 16, bottom: 48, left: 48 };
+    $: innerW = width - margin.left - margin.right;
+    $: innerH = height - margin.top - margin.bottom;
+
+    $: xStep = chrono.length > 1 ? innerW / (chrono.length - 1) : 0;
+
+    function xPos(i) {
+        if (chrono.length === 1) return margin.left + innerW / 2;
+        return margin.left + xStep * i;
+    }
+    function yPos(v) {
+        return margin.top + innerH - (v / yMax) * innerH;
+    }
+
+    function fmtDate(ts) {
+        try {
+            const d = new Date(ts);
+            return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+        } catch (e) {
+            return '';
+        }
+    }
+
+    $: line = chrono.map((r, i) => `${xPos(i)},${yPos(r.totalTime)}`).join(' ');
+
+    // Show up to ~8 evenly-spaced x labels
+    $: xLabelIdxs = (() => {
+        if (chrono.length <= 8) return chrono.map((_, i) => i);
+        const out = [];
+        const step = Math.max(1, Math.floor(chrono.length / 7));
+        for (let i = 0; i < chrono.length; i += step) out.push(i);
+        if (out[out.length - 1] !== chrono.length - 1) out.push(chrono.length - 1);
+        return out;
+    })();
+</script>
+
+{#if chrono.length === 0}
+    <p><em>Nu există date pentru graficul de evoluție.</em></p>
+{:else}
+    <div class="chart-wrap">
+        <svg viewBox="0 0 {width} {height}" preserveAspectRatio="xMidYMid meet" class="chart">
+            {#each yTicks as t}
+                <line
+                    x1={margin.left}
+                    x2={margin.left + innerW}
+                    y1={yPos(t)}
+                    y2={yPos(t)}
+                    class="grid"
+                />
+                <text x={margin.left - 6} y={yPos(t)} class="tick" text-anchor="end" dominant-baseline="middle">
+                    {t.toFixed(1)}s
+                </text>
+            {/each}
+
+            {#if chrono.length > 1}
+                <polyline points={line} fill="none" stroke="#4e79a7" stroke-width="2" />
+            {/if}
+
+            {#each chrono as r, i}
+                <circle
+                    cx={xPos(i)}
+                    cy={yPos(r.totalTime)}
+                    r={r.id === highlightId ? 5.5 : 3.5}
+                    fill={r.id === highlightId ? '#e15759' : '#4e79a7'}
+                    stroke="#fff"
+                    stroke-width="1"
+                >
+                    <title>{fmtDate(r.timestamp)}: {r.totalTime.toFixed(2)}s</title>
+                </circle>
+            {/each}
+
+            {#each xLabelIdxs as i}
+                <text
+                    x={xPos(i)}
+                    y={margin.top + innerH + 16}
+                    class="tick"
+                    text-anchor="middle"
+                >
+                    {fmtDate(chrono[i].timestamp)}
+                </text>
+            {/each}
+
+            <line x1={margin.left} x2={margin.left + innerW} y1={margin.top + innerH} y2={margin.top + innerH} class="axis" />
+            <line x1={margin.left} x2={margin.left} y1={margin.top} y2={margin.top + innerH} class="axis" />
+
+            <text x={margin.left + innerW / 2} y={height - 4} class="axis-title" text-anchor="middle">Data</text>
+            <text
+                x={-(margin.top + innerH / 2)}
+                y={12}
+                class="axis-title"
+                text-anchor="middle"
+                transform="rotate(-90)"
+            >Secunde</text>
+        </svg>
+    </div>
+{/if}
+
+<style>
+    .chart-wrap {
+        width: 100%;
+        max-width: 760px;
+    }
+    .chart {
+        width: 100%;
+        height: auto;
+        font-family: inherit;
+    }
+    .grid {
+        stroke: #d0d0d0;
+        stroke-width: 1;
+        stroke-dasharray: 2 2;
+    }
+    .axis {
+        stroke: #8a8a8a;
+        stroke-width: 1;
+    }
+    .tick {
+        fill: #555;
+        font-size: 11px;
+    }
+    .axis-title {
+        fill: #444;
+        font-size: 12px;
+        font-weight: bold;
+    }
+    :global(body.dark-mode) .grid {
+        stroke: #2c3a4a;
+    }
+    :global(body.dark-mode) .axis {
+        stroke: #6a7c92;
+    }
+    :global(body.dark-mode) .tick {
+        fill: #b9c3cf;
+    }
+    :global(body.dark-mode) .axis-title {
+        fill: #d7d7d7;
+    }
+</style>

--- a/src/components/charts/TotalTimeChart.svelte
+++ b/src/components/charts/TotalTimeChart.svelte
@@ -4,37 +4,56 @@
     /**
      * Renders the trend of total run time over time.
      * Runs are plotted in chronological order on the X axis (oldest to newest)
-     * and total time on the Y axis.
+     * and total time on the Y axis. The Y range is tight to the actual data
+     * (both min and max) so a series of e.g. 150–200s runs doesn't waste
+     * 75% of the chart on whitespace below 150s.
      */
     export let runs = [];
     export let highlightId = '';
 
     $: chrono = [...runs].sort((a, b) => a.timestamp - b.timestamp);
 
-    function niceCeil(v) {
-        if (v <= 0) return 1;
-        const pow = Math.pow(10, Math.floor(Math.log10(v)));
-        const n = v / pow;
+    function niceTickStep(rough) {
+        if (rough <= 0) return 1;
+        const pow = Math.pow(10, Math.floor(Math.log10(rough)));
+        const norm = rough / pow;
         let nice;
-        if (n <= 1) nice = 1;
-        else if (n <= 2) nice = 2;
-        else if (n <= 5) nice = 5;
+        if (norm < 1.5) nice = 1;
+        else if (norm < 3) nice = 2;
+        else if (norm < 7) nice = 5;
         else nice = 10;
         return nice * pow;
     }
 
-    $: maxTotal = chrono.reduce((m, r) => Math.max(m, r.totalTime || 0), 0);
-    $: yMax = niceCeil(Math.max(1, maxTotal * 1.05));
-    $: yTicks = (() => {
+    $: times = chrono.map((r) => r.totalTime || 0).filter((t) => isFinite(t));
+    $: minTotal = times.length > 0 ? Math.min(...times) : 0;
+    $: maxTotal = times.length > 0 ? Math.max(...times) : 1;
+
+    $: yAxis = (() => {
+        if (times.length === 0) return { yMin: 0, yMax: 1, step: 0.5, ticks: [0, 0.5, 1] };
+
+        // Pad both ends; when min === max use 10% of the value as padding so
+        // a single point still has a visible chart region.
+        const range = maxTotal - minTotal;
+        const padding = range > 0 ? range * 0.12 : Math.max(0.5, maxTotal * 0.1);
+        const rawMin = Math.max(0, minTotal - padding);
+        const rawMax = maxTotal + padding;
+
+        const span = rawMax - rawMin;
+        const step = niceTickStep(span / 5);
+        const yMin = Math.max(0, Math.floor(rawMin / step) * step);
+        const yMax = Math.ceil(rawMax / step) * step;
         const ticks = [];
-        const steps = 5;
-        for (let i = 0; i <= steps; i++) ticks.push((yMax * i) / steps);
-        return ticks;
+        for (let v = yMin; v <= yMax + step / 2; v += step) ticks.push(v);
+        return { yMin, yMax, step, ticks };
     })();
+    $: yMin = yAxis.yMin;
+    $: yMax = yAxis.yMax;
+    $: yTicks = yAxis.ticks;
 
     const width = 720;
     const height = 240;
-    const margin = { top: 16, right: 16, bottom: 48, left: 48 };
+    const margin = { top: 16, right: 16, bottom: 48, left: 56 };
     $: innerW = width - margin.left - margin.right;
     $: innerH = height - margin.top - margin.bottom;
 
@@ -45,7 +64,8 @@
         return margin.left + xStep * i;
     }
     function yPos(v) {
-        return margin.top + innerH - (v / yMax) * innerH;
+        const denom = yMax - yMin || 1;
+        return margin.top + innerH - ((v - yMin) / denom) * innerH;
     }
 
     function fmtDate(ts) {
@@ -57,9 +77,14 @@
         }
     }
 
+    function fmtTick(v) {
+        if (v >= 100) return `${v.toFixed(0)}s`;
+        if (v >= 10) return `${v.toFixed(0)}s`;
+        return `${v.toFixed(1)}s`;
+    }
+
     $: line = chrono.map((r, i) => `${xPos(i)},${yPos(r.totalTime)}`).join(' ');
 
-    // Show up to ~8 evenly-spaced x labels
     $: xLabelIdxs = (() => {
         if (chrono.length <= 8) return chrono.map((_, i) => i);
         const out = [];
@@ -84,7 +109,7 @@
                     class="grid"
                 />
                 <text x={margin.left - 6} y={yPos(t)} class="tick" text-anchor="end" dominant-baseline="middle">
-                    {t.toFixed(1)}s
+                    {fmtTick(t)}
                 </text>
             {/each}
 

--- a/src/components/concursgrupa/ConcursGrupa.svelte
+++ b/src/components/concursgrupa/ConcursGrupa.svelte
@@ -2,7 +2,9 @@
 	import VersesInput from '/src/components/VersesInput.svelte';
 	import WrittenText from '/src/components/WrittenText.svelte';
 	import ScoreSubmitForm from '/src/components/ScoreSubmitForm.svelte';
+	import RunHistory from '/src/components/RunHistory.svelte';
 	import { createStopwatch } from '/src/lib/stopwatch.js';
+	import { saveRun } from '/src/lib/runHistory.js';
 
 	export let round;
 	export let verses;
@@ -13,6 +15,8 @@
 
     let eligibleForScoring = false;
 	let scoreResetSignal = 0;
+	let runSavedForThisAttempt = false;
+	let lastSavedRunId = '';
 
 	let resetVersesInput = () => 0;
 
@@ -20,6 +24,7 @@
 	const stopwatchState = stopwatch.state;
 	$: timerStarted = $stopwatchState.hasStarted;
 	$: elapsedTime = $stopwatchState.elapsedTime;
+	$: splits = $stopwatchState.splits;
 
 	let verseIdx = 0;
 	$: if (verses) {
@@ -37,19 +42,42 @@
 
 	let discoveredVerseText = '';
 
+	$: verseLabels = verses.map((v, i) => (v && v.ref) ? v.ref : String(i + 1));
+
     $: if (!timerStarted && discoveredVerseText.length > 0) {
         if (!trainingMode) {
             eligibleForScoring = true;
         }
+        runSavedForThisAttempt = false;
         stopwatch.start();
     }
 
     $: if (timerStarted && verseIdx == verses.length) {
         stopwatch.stop();
+        if (eligibleForScoring && !runSavedForThisAttempt && round) {
+            runSavedForThisAttempt = true;
+            const saved = saveRun({
+                round,
+                totalTime: elapsedTime,
+                verseTimes: splits.slice(0, verses.length),
+                verseLabels
+            });
+            if (saved) {
+                lastSavedRunId = saved.id;
+            }
+        }
     }
 
     $: if (trainingMode) {
         eligibleForScoring = false;
+    }
+
+    function handleVerseDone() {
+        stopwatch.split();
+        if (verseIdx < verses.length) {
+            verseIdx++;
+        }
+        discoveredVerseText = '';
     }
 
     function reset() {
@@ -58,6 +86,7 @@
         verseIdx = 0;
         discoveredVerseText = '';
 		eligibleForScoring = false;
+		runSavedForThisAttempt = false;
 		resetVersesInput();
     }
 </script>

--- a/src/components/concursgrupa/ConcursGrupa.svelte
+++ b/src/components/concursgrupa/ConcursGrupa.svelte
@@ -79,12 +79,7 @@
 {#key crtVerse}
 	<VersesInput
 		inputText={crtVerse}
-		fnVerseDone={() => {
-			if (verseIdx < verses.length) {
-				verseIdx++;
-			}
-			discoveredVerseText = '';
-		}}
+		fnVerseDone={handleVerseDone}
 		bind:discoveredText={discoveredVerseText}
 		disableNextButton={!trainingMode}
 		bind:reset={resetVersesInput}
@@ -100,3 +95,12 @@
 </div>
 <br>
 <button on:click={reset}>Reset</button>
+
+{#if round}
+	<RunHistory
+		round={round}
+		title={`Istoric pentru ${round}`}
+		verseLabels={verseLabels}
+		highlightRunId={lastSavedRunId}
+	/>
+{/if}

--- a/src/components/concursgrupa/ConcursGrupa.svelte
+++ b/src/components/concursgrupa/ConcursGrupa.svelte
@@ -5,6 +5,7 @@
 	import RunHistory from '/src/components/RunHistory.svelte';
 	import { createStopwatch } from '/src/lib/stopwatch.js';
 	import { saveRun } from '/src/lib/runHistory.js';
+	import { countWords } from '/src/lib/verseWords.js';
 
 	export let round;
 	export let verses;
@@ -43,6 +44,7 @@
 	let discoveredVerseText = '';
 
 	$: verseLabels = verses.map((v, i) => (v && v.ref) ? v.ref : String(i + 1));
+	$: verseWordCounts = verses.map((v) => countWords(v && v.verse ? v.verse : ''));
 
     $: if (!timerStarted && discoveredVerseText.length > 0) {
         if (!trainingMode) {
@@ -60,7 +62,8 @@
                 round,
                 totalTime: elapsedTime,
                 verseTimes: splits.slice(0, verses.length),
-                verseLabels
+                verseLabels,
+                verseWordCounts
             });
             if (saved) {
                 lastSavedRunId = saved.id;
@@ -130,6 +133,7 @@
 		round={round}
 		title={`Istoric pentru ${round}`}
 		verseLabels={verseLabels}
+		verseWordCounts={verseWordCounts}
 		highlightRunId={lastSavedRunId}
 	/>
 {/if}

--- a/src/lib/runHistory.js
+++ b/src/lib/runHistory.js
@@ -11,6 +11,7 @@ const MAX_RUNS_PER_ROUND = 200;
  * @property {number} totalTime - total seconds for the run
  * @property {number[]} verseTimes - seconds spent on each verse, in order
  * @property {string[]} [verseLabels] - optional labels for each verse (e.g. verse refs / numbers)
+ * @property {number[]} [verseWordCounts] - typable words per verse, used to derive words-per-minute stats
  */
 
 const isBrowser = typeof window !== 'undefined' && typeof localStorage !== 'undefined';
@@ -86,7 +87,8 @@ export function saveRun(run) {
     timestamp: run.timestamp || Date.now(),
     totalTime: run.totalTime,
     verseTimes: run.verseTimes.map((t) => Math.max(0, Number(t) || 0)),
-    verseLabels: run.verseLabels ? [...run.verseLabels] : undefined
+    verseLabels: run.verseLabels ? [...run.verseLabels] : undefined,
+    verseWordCounts: run.verseWordCounts ? run.verseWordCounts.map((n) => Math.max(0, Number(n) || 0)) : undefined
   };
 
   list.push(stored);

--- a/src/lib/runHistory.js
+++ b/src/lib/runHistory.js
@@ -1,0 +1,145 @@
+import { writable } from 'svelte/store';
+
+const STORAGE_KEY = 'competitive-run-history-v1';
+const MAX_RUNS_PER_ROUND = 200;
+
+/**
+ * @typedef {Object} Run
+ * @property {string} id
+ * @property {string} round
+ * @property {number} timestamp - epoch ms when the run finished
+ * @property {number} totalTime - total seconds for the run
+ * @property {number[]} verseTimes - seconds spent on each verse, in order
+ * @property {string[]} [verseLabels] - optional labels for each verse (e.g. verse refs / numbers)
+ */
+
+const isBrowser = typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+
+/**
+ * @returns {Record<string, Run[]>}
+ */
+function readAll() {
+  if (!isBrowser) return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed;
+  } catch (e) {
+    console.warn('Failed to read run history from localStorage', e);
+    return {};
+  }
+}
+
+/**
+ * @param {Record<string, Run[]>} data
+ */
+function writeAll(data) {
+  if (!isBrowser) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch (e) {
+    console.warn('Failed to write run history to localStorage', e);
+  }
+}
+
+/** Reactive store reflecting the current full history. */
+export const runHistoryStore = writable(readAll());
+
+function refreshStore() {
+  runHistoryStore.set(readAll());
+}
+
+function generateId() {
+  return (
+    Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8)
+  );
+}
+
+/**
+ * @param {string} round
+ * @returns {Run[]}
+ */
+export function getRuns(round) {
+  const all = readAll();
+  const runs = all[round] || [];
+  return [...runs].sort((a, b) => b.timestamp - a.timestamp);
+}
+
+/**
+ * @param {Omit<Run, 'id' | 'timestamp'> & { timestamp?: number; id?: string }} run
+ * @returns {Run | undefined}
+ */
+export function saveRun(run) {
+  if (!isBrowser) return undefined;
+  if (!run || !run.round) return undefined;
+  if (!Array.isArray(run.verseTimes) || run.verseTimes.length === 0) return undefined;
+
+  const all = readAll();
+  const list = all[run.round] || [];
+
+  /** @type {Run} */
+  const stored = {
+    id: run.id || generateId(),
+    round: run.round,
+    timestamp: run.timestamp || Date.now(),
+    totalTime: run.totalTime,
+    verseTimes: run.verseTimes.map((t) => Math.max(0, Number(t) || 0)),
+    verseLabels: run.verseLabels ? [...run.verseLabels] : undefined
+  };
+
+  list.push(stored);
+  list.sort((a, b) => b.timestamp - a.timestamp);
+  if (list.length > MAX_RUNS_PER_ROUND) {
+    list.length = MAX_RUNS_PER_ROUND;
+  }
+
+  all[run.round] = list;
+  writeAll(all);
+  refreshStore();
+  return stored;
+}
+
+/**
+ * @param {string} round
+ * @param {string} runId
+ */
+export function deleteRun(round, runId) {
+  const all = readAll();
+  const list = all[round];
+  if (!list) return;
+  const next = list.filter((r) => r.id !== runId);
+  if (next.length === list.length) return;
+  if (next.length === 0) {
+    delete all[round];
+  } else {
+    all[round] = next;
+  }
+  writeAll(all);
+  refreshStore();
+}
+
+/**
+ * @param {string} round
+ */
+export function clearRound(round) {
+  const all = readAll();
+  if (!(round in all)) return;
+  delete all[round];
+  writeAll(all);
+  refreshStore();
+}
+
+/**
+ * Format an epoch ms timestamp as a short, locale-aware string.
+ * @param {number} ts
+ */
+export function formatTimestamp(ts) {
+  try {
+    const d = new Date(ts);
+    return d.toLocaleString();
+  } catch (e) {
+    return String(ts);
+  }
+}

--- a/src/lib/stopwatch.js
+++ b/src/lib/stopwatch.js
@@ -2,21 +2,25 @@ import { writable } from 'svelte/store';
 
 const initialState = {
   hasStarted: false,
-  elapsedTime: 0
+  elapsedTime: 0,
+  splits: /** @type {number[]} */ ([])
 };
 
 export function createStopwatch() {
   let startTime = 0;
   let interval = 0;
+  let lastSplitElapsed = 0;
 
-  const state = writable({ ...initialState });
+  const state = writable({ ...initialState, splits: [] });
 
   function start() {
     startTime = new Date().getTime();
+    lastSplitElapsed = 0;
     clearInterval(interval);
     state.set({
       hasStarted: true,
-      elapsedTime: 0
+      elapsedTime: 0,
+      splits: []
     });
 
     interval = setInterval(() => {
@@ -42,16 +46,39 @@ export function createStopwatch() {
     });
   }
 
+  /**
+   * Record a split. Returns the seconds elapsed since the previous split
+   * (or since start, for the first split).
+   * @returns {number}
+   */
+  function split() {
+    if (startTime === 0) {
+      return 0;
+    }
+    const now = new Date().getTime();
+    const totalElapsed = (now - startTime) / 1000;
+    const delta = Math.max(0, totalElapsed - lastSplitElapsed);
+    lastSplitElapsed = totalElapsed;
+    state.update((current) => ({
+      ...current,
+      elapsedTime: totalElapsed,
+      splits: [...(current.splits || []), delta]
+    }));
+    return delta;
+  }
+
   function reset() {
     clearInterval(interval);
     startTime = 0;
-    state.set({ ...initialState });
+    lastSplitElapsed = 0;
+    state.set({ ...initialState, splits: [] });
   }
 
   return {
     state,
     start,
     stop,
+    split,
     reset
   };
 }

--- a/src/lib/verseWords.js
+++ b/src/lib/verseWords.js
@@ -1,0 +1,25 @@
+/**
+ * Helpers for counting "typable" words in a verse — those are the ones the
+ * user must actually type a letter for. Words made entirely of punctuation
+ * are auto-skipped by VersesInput, so they should not be counted when
+ * deriving words-per-minute statistics.
+ */
+
+const LETTER_RE = /[a-zăâțţșşî]/i;
+
+/**
+ * @param {string} word
+ */
+export function wordHasLetter(word) {
+  if (typeof word !== 'string' || word.length === 0) return false;
+  return LETTER_RE.test(word);
+}
+
+/**
+ * Count the number of letter-containing words in a verse string.
+ * @param {string} verse
+ */
+export function countWords(verse) {
+  if (typeof verse !== 'string') return 0;
+  return verse.split(' ').filter((w) => w.length > 0 && wordHasLetter(w)).length;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a local-only run history for Competitive mode runs so you can see how each part of a chapter felt, compare against previous attempts, and watch your total-time trend.

## What you get

After completing a competitive run, an **Istoric încercări** panel appears below the chapter. It contains:

- **Per-verse speed chart** — defaults to **cuvinte / minut**, with a `cuv/min ⇄ secunde` toggle. Verse length is normalized so a fast-but-long verse no longer looks slow. **Bars are colour-coded** (red → yellow → green) by per-verse goodness within the latest selected run: green = best verse, red = worst. In `cuv/min` mode green = high value, in `secunde` mode green = low value. Y axis is tight to the actual peak (no wasted whitespace).
- **Total-time trend** — line chart of total run times in chronological order. **Both min and max of the Y axis are tight to the actual data** so a series of e.g. 150–200s runs uses the whole chart instead of cramming everything into the top 25%.
- **Runs table** — every saved run with date, total seconds, total cuv/min, delta vs latest, one-click `Compară cu ultima`, individual `Șterge` (delete) buttons, plus a `Șterge tot istoricul` action. Legend swatches stay in sync with the chart: the gradient ribbon marks whichever run is drawn as bars; other selected runs show the same palette colour as their dashed line on the graph, and both update immediately when you change which runs are checked.

Runs are auto-saved to `localStorage` (key: `competitive-run-history-v1`) when an eligible-for-scoring run finishes, scoped by `round`. Nothing is uploaded to AWS.

## Where it shows up

- Homepage Romani/Evrei chapters (`SequentialTraining` + competitive checkbox)
- Concurs grupa stages and Training grounds stages (`ConcursGrupa`)

## Testing

End-to-end via headless Chrome. Verified swatch ↔ chart colour sync: with 3 runs selected, oldest shows `#f28e2b` (palette[2]); after unchecking the latest, oldest updates to `#4e79a7` (palette[1]) matching the chart polyline stroke.

[Istoric panel in WPM mode](https://cursor.com/agents/bc-0ce59a08-968f-49f0-9257-fe04d68bd2f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frun_history_wpm_panel.png)
[Total-time trend with tight Y axis](https://cursor.com/agents/bc-0ce59a08-968f-49f0-9257-fe04d68bd2f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frun_history_tight_trend.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ce59a08-968f-49f0-9257-fe04d68bd2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce59a08-968f-49f0-9257-fe04d68bd2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

