### PR TITLE
Trim whitespace from name when submitting a score

### DIFF
--- a/src/components/ScoreSubmitForm.svelte
+++ b/src/components/ScoreSubmitForm.svelte
@@ -17,6 +17,7 @@
 	}
 
 	async function handleSubmit() {
+		userName = userName.trim();
 		const response = await submitScore(score, userName, round);
 		if (response !== undefined) {
 			submitted = true;

--- a/src/lib/scoreApi.js
+++ b/src/lib/scoreApi.js
@@ -8,6 +8,8 @@ const SCORES_URL = 'https://dz5rd0lqnb.execute-api.eu-central-1.amazonaws.com/Pr
  * @param {string} round
  */
 export async function submitScore(score, name, round) {
+  name = name.trim();
+
   if (name === '') {
     alert('Numele nu poate fi gol');
     return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When submitting a competitive score, the name field (`Nume`) is now trimmed of leading and trailing whitespace before validation and before sending to the API.

## Changes
- `ScoreSubmitForm.svelte`: trim `userName` on submit so the input reflects the value sent
- `scoreApi.js`: trim `name` in `submitScore` so all callers get consistent behavior

## Behavior
- `"  Ana  "` is submitted as `"Ana"`
- A name that is only spaces still shows the existing alert: *Numele nu poate fi gol*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-073f930c-e65d-4557-b22b-4d981b71f73a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-073f930c-e65d-4557-b22b-4d981b71f73a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

